### PR TITLE
feat: 서버 컨트롤러 공통 응답 및 예외 설정

### DIFF
--- a/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
@@ -1,0 +1,71 @@
+package store.sonyk9919.api.global.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@JsonPropertyOrder({"isSuccess", "code", "message", "data"})
+public class BaseResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    private BaseResponse(Boolean isSuccess, BaseResponseStatus status, T data) {
+        this.isSuccess = isSuccess;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.data = data;
+    }
+
+    private BaseResponse(Boolean isSuccess, BaseResponseStatus status, String customMessage, T data) {
+        this.isSuccess = isSuccess;
+        this.code = status.getCode();
+        this.message = customMessage;
+        this.data = data;
+    }
+
+    public static ResponseEntity<BaseResponse<Void>> success() {
+        BaseResponseStatus success = SuccessStatus.SUCCESS;
+
+        return ResponseEntity
+                .status(success.getHttpStatus())
+                .body(new BaseResponse<>(true, success, null));
+    }
+
+    public static <T> ResponseEntity<BaseResponse<T>> success(T data) {
+        BaseResponseStatus success = SuccessStatus.SUCCESS;
+
+        return ResponseEntity
+                .status(success.getHttpStatus())
+                .body(new BaseResponse<>(true, success, data));
+    }
+
+    public static <T> ResponseEntity<BaseResponse<T>> success(BaseResponseStatus status, T data) {
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(true, status, data));
+    }
+
+    public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status) {
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(false, status, null));
+    }
+
+    public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status, String customMessage) {
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(false, status, customMessage, null));
+    }
+
+    public static <T> ResponseEntity<BaseResponse<T>> error(BaseResponseStatus status, T data) {
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(false, status, data));
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
@@ -1,71 +1,51 @@
 package store.sonyk9919.api.global.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
 @Getter
-@JsonPropertyOrder({"isSuccess", "code", "message", "data"})
+@JsonPropertyOrder({"code", "message", "data"})
 public class BaseResponse<T> {
-
-    @JsonProperty("isSuccess")
-    private final Boolean isSuccess;
     private final String code;
     private final String message;
     private final T data;
 
-    private BaseResponse(Boolean isSuccess, BaseResponseStatus status, T data) {
-        this.isSuccess = isSuccess;
+    private BaseResponse(BaseResponseStatus status, String message, T data) {
         this.code = status.getCode();
-        this.message = status.getMessage();
-        this.data = data;
-    }
-
-    private BaseResponse(Boolean isSuccess, BaseResponseStatus status, String customMessage, T data) {
-        this.isSuccess = isSuccess;
-        this.code = status.getCode();
-        this.message = customMessage;
+        this.message = message;
         this.data = data;
     }
 
     public static ResponseEntity<BaseResponse<Void>> success() {
-        BaseResponseStatus success = SuccessStatus.SUCCESS;
-
-        return ResponseEntity
-                .status(success.getHttpStatus())
-                .body(new BaseResponse<>(true, success, null));
+        return build(SuccessStatus.SUCCESS, null, null);
     }
 
     public static <T> ResponseEntity<BaseResponse<T>> success(T data) {
-        BaseResponseStatus success = SuccessStatus.SUCCESS;
-
-        return ResponseEntity
-                .status(success.getHttpStatus())
-                .body(new BaseResponse<>(true, success, data));
+        return build(SuccessStatus.SUCCESS, null, data);
     }
 
     public static <T> ResponseEntity<BaseResponse<T>> success(BaseResponseStatus status, T data) {
-        return ResponseEntity
-                .status(status.getHttpStatus())
-                .body(new BaseResponse<>(true, status, data));
+        return build(status, null, data);
     }
 
     public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status) {
-        return ResponseEntity
-                .status(status.getHttpStatus())
-                .body(new BaseResponse<>(false, status, null));
+        return build(status, null, null);
     }
 
     public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status, String customMessage) {
-        return ResponseEntity
-                .status(status.getHttpStatus())
-                .body(new BaseResponse<>(false, status, customMessage, null));
+        return build(status, customMessage, null);
     }
 
     public static <T> ResponseEntity<BaseResponse<T>> error(BaseResponseStatus status, T data) {
+        return build(status, null, data);
+    }
+
+    private static <T> ResponseEntity<BaseResponse<T>> build(BaseResponseStatus status, String customMessage, T data) {
+        String message = (customMessage != null) ? customMessage : status.getMessage();
+
         return ResponseEntity
                 .status(status.getHttpStatus())
-                .body(new BaseResponse<>(false, status, data));
+                .body(new BaseResponse<>(status, message, data));
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponseStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponseStatus.java
@@ -1,0 +1,9 @@
+package store.sonyk9919.api.global.common.dto;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseResponseStatus {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
@@ -8,15 +8,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseResponseStatus {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
-    VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "VALIDATION_FAIL", "입력값이 올바르지 않습니다."),
-    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "요청 본문 형식이 올바르지 않습니다."),
-    NO_PERMISSION(HttpStatus.FORBIDDEN, "NO_PERMISSION", "해당 리소스에 접근할 권한이 없습니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"METHOD_NOT_ALLOWED","지원하지 않는 HTTP 메소드 입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "COMMON_400_1", "요청 본문 형식이 올바르지 않습니다."),
+    VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "COMMON_400_2", "입력값이 올바르지 않습니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "COMMON_403", "접근 권한이 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"COMMON_405","지원하지 않는 HTTP 메소드 입니다."),
 
-    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE_ERROR", "데이터베이스 오류가 발생했습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
-
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
@@ -1,0 +1,26 @@
+package store.sonyk9919.api.global.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseResponseStatus {
+
+    // 4xx
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+    VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "VALIDATION_FAIL", "입력값이 올바르지 않습니다."),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "요청 본문 형식이 올바르지 않습니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "NO_PERMISSION", "해당 리소스에 접근할 권한이 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"METHOD_NOT_ALLOWED","지원하지 않는 HTTP 메소드 입니다."),
+
+    // 5xx
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE_ERROR", "데이터베이스 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
@@ -8,14 +8,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseResponseStatus {
 
-    // 4xx
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
     VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "VALIDATION_FAIL", "입력값이 올바르지 않습니다."),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "INVALID_REQUEST_BODY", "요청 본문 형식이 올바르지 않습니다."),
     NO_PERMISSION(HttpStatus.FORBIDDEN, "NO_PERMISSION", "해당 리소스에 접근할 권한이 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"METHOD_NOT_ALLOWED","지원하지 않는 HTTP 메소드 입니다."),
 
-    // 5xx
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DATABASE_ERROR", "데이터베이스 오류가 발생했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/store/sonyk9919/api/global/common/dto/SuccessStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/SuccessStatus.java
@@ -1,0 +1,17 @@
+package store.sonyk9919.api.global.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseResponseStatus {
+
+    SUCCESS(HttpStatus.OK,"SUCCESS","성공입니다."),
+    CREATED(HttpStatus.CREATED, "CREATED", "생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/global/common/dto/SuccessStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/SuccessStatus.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessStatus implements BaseResponseStatus {
 
-    SUCCESS(HttpStatus.OK,"SUCCESS","성공입니다."),
-    CREATED(HttpStatus.CREATED, "CREATED", "생성되었습니다.");
+    SUCCESS(HttpStatus.OK,"COMMON_200","성공입니다."),
+    CREATED(HttpStatus.CREATED, "COMMON_201", "생성되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/global/common/exception/CustomException.java
+++ b/src/main/java/store/sonyk9919/api/global/common/exception/CustomException.java
@@ -1,0 +1,19 @@
+package store.sonyk9919.api.global.common.exception;
+
+import lombok.Getter;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final BaseResponseStatus status;
+
+    public CustomException(BaseResponseStatus status){
+        super(status.getMessage());
+        this.status = status;
+    }
+
+    public CustomException(BaseResponseStatus status, String message){
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package store.sonyk9919.api.global.common.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import store.sonyk9919.api.global.common.dto.BaseResponse;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+import store.sonyk9919.api.global.common.dto.ErrorStatus;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<BaseResponse<Void>> handleCustomException(CustomException e, HttpServletRequest request) {
+        BaseResponseStatus status = e.getStatus();
+
+        log.warn("CustomException occurred at {}: [{}] {}",
+                request.getRequestURI(), status.getCode(), e.getMessage());
+        return BaseResponse.error(status, e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException e, HttpServletRequest request) {
+        Map<String, String> errors = getErrors(e);
+
+        log.warn("Validation failed at {}: {}", request.getRequestURI(), errors);
+        return BaseResponse.error(ErrorStatus.VALIDATION_FAIL, errors);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<BaseResponse<Void>> handleJsonParsingExceptions(HttpMessageNotReadableException e, HttpServletRequest request) {
+        log.warn("JSON parsing failed at {}: {}", request.getRequestURI(), e.getMessage());
+        return BaseResponse.error(ErrorStatus.INVALID_REQUEST_BODY);
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<BaseResponse<Void>> handleDataAccessException(DataAccessException e, HttpServletRequest request) {
+        log.warn("DataAccessException occurred at {}: {}", request.getRequestURI(), e.getMessage());
+        return BaseResponse.error(ErrorStatus.DATABASE_ERROR);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<BaseResponse<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+        log.warn("Method Not Allowed at {}: {}", request.getRequestURI(), e.getMessage());
+        return BaseResponse.error(ErrorStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<Void>> handleException(Exception e, HttpServletRequest request) {
+        log.error("Unhandled Exception occurred at {}: ", request.getRequestURI(), e);
+        return BaseResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private Map<String, String> getErrors(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+        BindingResult bindingResult = e.getBindingResult();
+
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            String field = error.getField();
+            String defaultMessage = error.getDefaultMessage();
+
+            errors.put(field, defaultMessage);
+        }
+        return errors;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataAccessException.class)
     public ResponseEntity<BaseResponse<Void>> handleDataAccessException(DataAccessException e, HttpServletRequest request) {
         log.warn("DataAccessException occurred at {}: {}", request.getRequestURI(), e.getMessage());
-        return BaseResponse.error(ErrorStatus.DATABASE_ERROR);
+        return BaseResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)


### PR DESCRIPTION
## 개요
- Jira 서버 컨트롤러 공통 응답 및 예외 세팅 (https://untitled.atlassian.net/browse/KAN-105)
- API 응답 통일 및 전역 예외 처리기를 통해 에러 핸들링 구조 구현

## 변경 내용
- 공통 응답 포맷: BaseResponse<T> 도입으로 성공/실패 응답 구조 통일 (isSuccess, code, message, data)
  - 모든 API 응답은 BaseResponse<T>로 감싸서 나갑니다.

- 상태 코드 관리: SuccessStatus, ErrorStatus Enum을 활용해 HTTP 상태 코드와 비즈니스 응답 코드 통일
- 전역 예외 처리: @RestControllerAdvice 기반 GlobalExceptionHandler 구현
	- 비즈니스 로직 예외 (CustomException) 처리
	- 에러 발생 url와 메세지를 로그로 찍어냅니다.
	- 구체적인 예외 외 나머지는 Exception.class로 500 에러로 처리

## 스크린 샷
- JSON 응답 예시는 Jira를 참고해주세요.

## 참고 사항
- 다음과 같은 형태로 구현해 보았는데 혹시 더 선호하는 필드명/구조가 있다면 편하게 의견 주시면 반영하겠습니다.