### PR TITLE
fix: H2 Console에 접근할 수 없는 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.springframework.boot:spring-boot-h2console'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 


### PR DESCRIPTION
## 개요

- 아래와 같이 H2 Console과 관련된 설정은 존재 하지만 서버 기동 시 접근이 불가한 문제가 있다.

```yml
spring:
  h2:
    console:
      enabled: true
      path: /h2-console
      settings:
        web-allow-others: true
```

## 원인

- 스프링 부트의 Major 버전이 올라가면서 (e.g. 4.x.x) AutoConfiguration 과 관련된 의존성이 분리된 것으로 보인다.
  - https://medium.com/@raushan1156/h2-console-not-working-in-spring-boot-4-0-0-7873e20c82d5

## 해결

- 따라서 H2 Console의 AutoConfiguration과 관련된 의존성을 추가한다.
  - https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-h2console/4.0.1

