### PR TITLE
feat: 쓰레기 분석 요청 및 결과 엔티티 설계

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
@@ -1,12 +1,15 @@
 package store.sonyk9919.api.domain.analysis.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import store.sonyk9919.api.global.common.entity.BaseEntity;
 import java.util.UUID;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(
         name = "createdAt",
         column = @Column(name = "request_at", updatable = false)
@@ -21,7 +24,11 @@ public class AnalysisRequest extends BaseEntity {
     @Column(name = "request_id", nullable = false, unique = true)
     private String requestId;
 
-    public AnalysisRequest() {
-        this.requestId = UUID.randomUUID().toString();
+    private AnalysisRequest(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public static AnalysisRequest createWithUUID() {
+        return new AnalysisRequest(UUID.randomUUID().toString());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
@@ -1,0 +1,27 @@
+package store.sonyk9919.api.domain.analysis.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import store.sonyk9919.api.global.common.entity.BaseEntity;
+import java.util.UUID;
+
+@Entity
+@Getter
+@AttributeOverride(
+        name = "createdAt",
+        column = @Column(name = "request_at", updatable = false)
+)
+public class AnalysisRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "analysis_request_id")
+    private Long id;
+
+    @Column(name = "request_id", nullable = false, unique = true)
+    private String requestId;
+
+    public AnalysisRequest() {
+        this.requestId = UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisResult.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisResult.java
@@ -1,0 +1,21 @@
+package store.sonyk9919.api.domain.analysis.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import store.sonyk9919.api.global.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AttributeOverride(
+        name = "createdAt",
+        column = @Column(name = "result_at", updatable = false)
+)
+public class AnalysisResult extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "result_id")
+    private Long id;
+}

--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisResult.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisResult.java
@@ -1,13 +1,14 @@
 package store.sonyk9919.api.domain.analysis.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import store.sonyk9919.api.global.common.entity.BaseEntity;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(
         name = "createdAt",
         column = @Column(name = "result_at", updatable = false)
@@ -18,4 +19,8 @@ public class AnalysisResult extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "result_id")
     private Long id;
+
+    public static AnalysisResult create() {
+        return new AnalysisResult();
+    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/analysis/repository/AnalysisRequestRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/repository/AnalysisRequestRepository.java
@@ -1,0 +1,7 @@
+package store.sonyk9919.api.domain.analysis.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
+
+public interface AnalysisRequestRepository extends JpaRepository<AnalysisRequest, Long> {
+}

--- a/src/main/java/store/sonyk9919/api/domain/analysis/repository/AnalysisResultRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/repository/AnalysisResultRepository.java
@@ -1,0 +1,7 @@
+package store.sonyk9919.api.domain.analysis.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisResult;
+
+public interface AnalysisResultRepository extends JpaRepository<AnalysisResult, Long> {
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
@@ -1,0 +1,56 @@
+package store.sonyk9919.api.domain.trash.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisResult;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Trash {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trash_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    private AnalysisRequest analysisRequest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "result_id", nullable = true)
+    private AnalysisResult analysisResult;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private TrashCategory trashCategory;
+
+    private String label;
+    private String material;
+    private String filename;
+
+    @Builder
+    public Trash(AnalysisRequest analysisRequest, TrashCategory trashCategory,
+                 String label, String material, String filename) {
+        this.analysisRequest = analysisRequest;
+        this.trashCategory = trashCategory;
+        this.label = label;
+        this.material = material;
+        this.filename = filename;
+    }
+
+    public void confirmResult(AnalysisResult analysisResult) {
+        this.analysisResult = analysisResult;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
@@ -1,14 +1,7 @@
 package store.sonyk9919.api.domain.trash.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.Builder;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
@@ -16,7 +9,7 @@ import store.sonyk9919.api.domain.analysis.entity.AnalysisResult;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Trash {
 
     @Id
@@ -40,14 +33,18 @@ public class Trash {
     private String material;
     private String filename;
 
-    @Builder
-    public Trash(AnalysisRequest analysisRequest, TrashCategory trashCategory,
+    private Trash(AnalysisRequest analysisRequest, TrashCategory trashCategory,
                  String label, String material, String filename) {
         this.analysisRequest = analysisRequest;
         this.trashCategory = trashCategory;
         this.label = label;
         this.material = material;
         this.filename = filename;
+    }
+
+    public static Trash create(AnalysisRequest analysisRequest, TrashCategory trashCategory,
+                               String label, String material, String filename) {
+        return new Trash(analysisRequest,trashCategory,label,material,filename);
     }
 
     public void confirmResult(AnalysisResult analysisResult) {

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashCategory.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashCategory.java
@@ -1,0 +1,31 @@
+package store.sonyk9919.api.domain.trash.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class TrashCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "disposal_guide", columnDefinition = "TEXT")
+    private String disposalGuide;
+
+    public TrashCategory(String name, String disposalGuide) {
+        this.name = name;
+        this.disposalGuide = disposalGuide;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashCategory.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashCategory.java
@@ -1,16 +1,13 @@
 package store.sonyk9919.api.domain.trash.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrashCategory {
 
     @Id
@@ -24,8 +21,12 @@ public class TrashCategory {
     @Column(name = "disposal_guide", columnDefinition = "TEXT")
     private String disposalGuide;
 
-    public TrashCategory(String name, String disposalGuide) {
+    private TrashCategory(String name, String disposalGuide) {
         this.name = name;
         this.disposalGuide = disposalGuide;
+    }
+
+    public static TrashCategory create(String name, String disposalGuide){
+        return new TrashCategory(name,disposalGuide);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashCategoryRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashCategoryRepository.java
@@ -1,0 +1,7 @@
+package store.sonyk9919.api.domain.trash.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.trash.entity.TrashCategory;
+
+public interface TrashCategoryRepository extends JpaRepository<TrashCategory, Long> {
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
@@ -1,0 +1,7 @@
+package store.sonyk9919.api.domain.trash.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.trash.entity.Trash;
+
+public interface TrashRepository extends JpaRepository<Trash, Long> {
+}


### PR DESCRIPTION
## 개요
- Jira: 분석 요청 및 결과 엔티티 설계 (https://untitled.atlassian.net/browse/KAN-60)
- 분석 기능의 기반이 되는 데이터베이스 테이블(`AnalysisRequest`, `AnalysisResult`, `Trash`, `TrashCategory`) 구축 및 기본 Repository 구현

## 변경 내용
- `AnalysisRequest` 
    - 내부 식별자(`id`, Long)와 외부 통신용 식별자(`requestId`, UUID)를 분리
- `Trash` 
    * `AnalysisResult`와의 연관관계를 `nullable = true`로 설정 (AI 분석 직후에는 아직 확정된 결과가 없을 수 있으므로, 초기에는 `null` 상태를 허용하고 사용자가 확정 시 업데이트 하기)
    * 결과 확정을 위한 편의 메서드 `confirmResult()`를 추가.

## 스크린 샷
<img width="443" height="540" alt="image" src="https://github.com/user-attachments/assets/3b9ab635-ae46-449c-9a50-916bb79240c9" />


## 참고 사항
<img width="1024" height="443" alt="image" src="https://github.com/user-attachments/assets/71751f17-394c-4313-ac59-0f9574c42e78" />
