### PR TITLE
fix: application-secret.yml 부재 시 서버 기동 실패

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,8 +38,8 @@ logging:
     org.springframework.transaction.interceptor: TRACE
 
 file:
-  upload-dir: ${custom.dev.uploadDir}
+  upload-dir: ${custom.dev.uploadDir:./upload/}
 
 analysis:
   fastApi:
-    url: ${custom.dev.fastApiUrl}
+    url: ${custom.dev.fastApiUrl:http://localhost:8989}


### PR DESCRIPTION
## 주요 변경사항

### Chore

- application-dev.yml에 기본 값 설정

## 상세 설명

- application-secret.yml 부재 시 서버 기동 실패하므로 생산성을 위해 dev에 대해서만 기본값을 설정

## 체크리스트

- [x] 수정 이후 서버 기동

## 참고사항

- 없음