### PR TITLE
feat: Jwt 기반의 인증/인가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    systemProperty "spring.profiles.active", "test"
 }
 
 tasks.withType(Test).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'

--- a/src/main/java/store/sonyk9919/api/ApiApplication.java
+++ b/src/main/java/store/sonyk9919/api/ApiApplication.java
@@ -2,12 +2,14 @@ package store.sonyk9919.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/store/sonyk9919/api/domain/auth/dto/AuthMemberDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/dto/AuthMemberDto.java
@@ -1,0 +1,45 @@
+package store.sonyk9919.api.domain.auth.dto;
+
+import io.jsonwebtoken.Claims;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.member.entitiy.AccountRole;
+import store.sonyk9919.api.domain.member.entitiy.MemberAccount;
+import store.sonyk9919.api.global.jwt.dto.ClaimsConvertible;
+
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthMemberDto implements ClaimsConvertible {
+    private final Long id;
+    private final AccountRole role;
+
+    public static AuthMemberDto from(MemberAccount account) {
+        return new AuthMemberDto(account.getId(), account.getRole());
+    }
+
+    public static AuthMemberDto from(Claims claims) {
+        return new AuthMemberDto(
+                Long.valueOf(claims.getSubject()),
+                AccountRole.findByKey(claims.get(Body.ROLE, String.class))
+        );
+    }
+
+    @Override
+    public String getSubject() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public Map<String, Object> getBody() {
+        return Map.of(
+                Body.ROLE, role.getKey()
+        );
+    }
+
+    private static class Body {
+        public static final String ROLE = "role";
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenCookieName.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenCookieName.java
@@ -1,0 +1,5 @@
+package store.sonyk9919.api.domain.auth.dto;
+
+public interface TokenCookieName {
+    String ACCESS_TOKEN = "accessToken";
+}

--- a/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,18 @@
+package store.sonyk9919.api.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenResponseDto {
+
+    private final String name;
+    private final String token;
+    private final Long expiry;
+
+    public static TokenResponseDto from(String name, String token, Long expiry) {
+        return new TokenResponseDto(name, token, expiry);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package store.sonyk9919.api.domain.auth.filter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.dto.TokenCookieName;
+import store.sonyk9919.api.global.common.exception.CustomException;
+import store.sonyk9919.api.global.cookie.CookieProvider;
+import store.sonyk9919.api.global.jwt.service.JwtProvider;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final CookieProvider cookieProvider;
+    private final JwtProvider jwtProvider;
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String accessToken = cookieProvider.resolveCookie(request, TokenCookieName.ACCESS_TOKEN);
+
+        try {
+            if (accessToken != null) {
+                Claims claims = jwtProvider.parseJwt(accessToken);
+                injectSecurityContext(AuthMemberDto.from(claims));
+            }
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            cookieProvider.expireCookie(response, TokenCookieName.ACCESS_TOKEN);
+            handlerExceptionResolver.resolveException(request, response, null, e);
+        }
+
+    }
+
+    private void injectSecurityContext(AuthMemberDto member) {
+        List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(member.getRole().getKey()));
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(member, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
@@ -1,0 +1,24 @@
+package store.sonyk9919.api.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
+import store.sonyk9919.api.domain.member.entitiy.MemberAccount;
+import store.sonyk9919.api.domain.member.service.MemberAccountService;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuthLoginFacade {
+
+    private final MemberAccountService memberAccountService;
+    private final AuthTokenIssuer authTokenIssuer;
+
+    public List<TokenResponseDto> login(String name, String password) {
+        MemberAccount memberAccount = memberAccountService.getMemberAccount(name, password);
+
+        return authTokenIssuer.issue(AuthMemberDto.from(memberAccount));
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
@@ -1,0 +1,32 @@
+package store.sonyk9919.api.domain.auth.service;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.dto.TokenCookieName;
+import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
+import store.sonyk9919.api.global.jwt.service.JwtProvider;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuthTokenIssuer {
+
+    private final JwtProvider jwtProvider;
+
+    @Value("${jwt.expiry.access}")
+    private long accessTokenExpiry;
+
+    public List<TokenResponseDto> issue(AuthMemberDto member) {
+        return List.of(issueAccessToken(member));
+    }
+
+    private TokenResponseDto issueAccessToken(AuthMemberDto member) {
+        Claims claims = jwtProvider.createClaims(member);
+        String jwt = jwtProvider.createJwt(claims, accessTokenExpiry);
+        return TokenResponseDto.from(TokenCookieName.ACCESS_TOKEN, jwt, accessTokenExpiry);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/entitiy/AccountRole.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entitiy/AccountRole.java
@@ -1,0 +1,25 @@
+package store.sonyk9919.api.domain.member.entitiy;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.member.exception.MemberStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum AccountRole {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+
+    public static AccountRole findByKey(String key) {
+        return Arrays.stream(AccountRole.values())
+                .filter(role -> role.getKey().equals(key))
+                .findAny()
+                .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_BAD_REQUEST));
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/entitiy/MemberAccount.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entitiy/MemberAccount.java
@@ -1,0 +1,36 @@
+package store.sonyk9919.api.domain.member.entitiy;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AccountRole role;
+
+    private MemberAccount(String name, String password, AccountRole role) {
+        this.name = name;
+        this.password = password;
+        this.role = role;
+    }
+
+    public static MemberAccount from(String name, String password, AccountRole role) {
+        return new MemberAccount(name, password, role);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
@@ -1,0 +1,17 @@
+package store.sonyk9919.api.domain.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus implements BaseResponseStatus {
+    MEMBER_ACCOUNT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER-001", "아이디 또는 비밀번호가 일치하지 않습니다."),
+    MEMBER_ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER-002", "잘 못 된 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/repository/MemberAccountRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/repository/MemberAccountRepository.java
@@ -1,0 +1,11 @@
+package store.sonyk9919.api.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.member.entitiy.MemberAccount;
+
+import java.util.Optional;
+
+public interface MemberAccountRepository extends JpaRepository<MemberAccount, Long> {
+
+    Optional<MemberAccount> findByName(String username);
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
@@ -1,0 +1,30 @@
+package store.sonyk9919.api.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.member.entitiy.AccountRole;
+import store.sonyk9919.api.domain.member.entitiy.MemberAccount;
+import store.sonyk9919.api.domain.member.exception.MemberStatus;
+import store.sonyk9919.api.domain.member.repository.MemberAccountRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberAccountService {
+
+    private final MemberAccountRepository memberAccountRepository;
+
+    @Transactional
+    public MemberAccount createMemberAccount(String name, String password) {
+        MemberAccount memberAccount = MemberAccount.from(name, password, AccountRole.USER);
+        memberAccountRepository.save(memberAccount);
+        return memberAccount;
+    }
+
+    public MemberAccount getMemberAccount(String name) {
+        return memberAccountRepository.findByName(name)
+                .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_UNAUTHORIZED));
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
@@ -1,6 +1,7 @@
 package store.sonyk9919.api.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.member.entitiy.AccountRole;
@@ -15,16 +16,23 @@ import store.sonyk9919.api.global.common.exception.CustomException;
 public class MemberAccountService {
 
     private final MemberAccountRepository memberAccountRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public MemberAccount createMemberAccount(String name, String password) {
-        MemberAccount memberAccount = MemberAccount.from(name, password, AccountRole.USER);
+        MemberAccount memberAccount = MemberAccount.from(name, passwordEncoder.encode(password), AccountRole.USER);
         memberAccountRepository.save(memberAccount);
         return memberAccount;
     }
 
-    public MemberAccount getMemberAccount(String name) {
-        return memberAccountRepository.findByName(name)
+    public MemberAccount getMemberAccount(String name, String password) {
+        MemberAccount memberAccount = memberAccountRepository.findByName(name)
                 .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_UNAUTHORIZED));
+
+        if (!passwordEncoder.matches(password, memberAccount.getPassword())) {
+            throw new CustomException(MemberStatus.MEMBER_ACCOUNT_UNAUTHORIZED);
+        }
+
+        return memberAccount;
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package store.sonyk9919.api.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import store.sonyk9919.api.global.config.property.CorsProperty;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CorsProperty corsProperty;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) {
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(corsProperty.getOrigins());
+        corsConfiguration.setAllowedMethods(corsProperty.getMethods());
+        corsConfiguration.setAllowedHeaders(corsProperty.getHeaders());
+        corsConfiguration.setMaxAge(corsProperty.getMaxAge());
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration(corsProperty.getPath(), corsConfiguration);
+        return source;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
@@ -9,9 +9,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import store.sonyk9919.api.domain.auth.filter.JwtAuthenticationFilter;
+import store.sonyk9919.api.domain.member.entitiy.AccountRole;
 import store.sonyk9919.api.global.config.property.CorsProperty;
 
 @Configuration
@@ -20,6 +23,7 @@ import store.sonyk9919.api.global.config.property.CorsProperty;
 public class SecurityConfig {
 
     private final CorsProperty corsProperty;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) {
@@ -32,7 +36,8 @@ public class SecurityConfig {
                         .anyRequest().permitAll()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return httpSecurity.build();
     }
 

--- a/src/main/java/store/sonyk9919/api/global/config/SecurityHelperConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/SecurityHelperConfig.java
@@ -1,0 +1,15 @@
+package store.sonyk9919.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityHelperConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/property/CookieProperty.java
+++ b/src/main/java/store/sonyk9919/api/global/config/property/CookieProperty.java
@@ -1,0 +1,14 @@
+package store.sonyk9919.api.global.config.property;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "security.cookie")
+public class CookieProperty {
+
+    private final String sameSite;
+    private final String domain;
+}

--- a/src/main/java/store/sonyk9919/api/global/config/property/CorsProperty.java
+++ b/src/main/java/store/sonyk9919/api/global/config/property/CorsProperty.java
@@ -1,0 +1,21 @@
+package store.sonyk9919.api.global.config.property;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Getter
+@ConfigurationProperties(prefix = "security.cors")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class CorsProperty {
+
+    private final List<String> origins;
+    private final List<String> methods;
+    private final List<String> headers;
+    private final String path;
+    private final Long maxAge;
+}

--- a/src/main/java/store/sonyk9919/api/global/cookie/CookieProvider.java
+++ b/src/main/java/store/sonyk9919/api/global/cookie/CookieProvider.java
@@ -1,0 +1,38 @@
+package store.sonyk9919.api.global.cookie;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.global.config.property.CookieProperty;
+
+@Component
+@RequiredArgsConstructor
+public class CookieProvider {
+
+    private final CookieProperty cookieProperty;
+
+    public void addCookie(HttpServletResponse response, String name, String value, Long expiry) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(expiry)
+                .sameSite(cookieProperty.getSameSite())
+                .domain(cookieProperty.getDomain())
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public void expireCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .maxAge(0)
+                .domain(cookieProperty.getDomain())
+                .path("/")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/cookie/CookieProvider.java
+++ b/src/main/java/store/sonyk9919/api/global/cookie/CookieProvider.java
@@ -1,11 +1,15 @@
 package store.sonyk9919.api.global.cookie;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.global.config.property.CookieProperty;
+
+import java.util.Arrays;
 
 @Component
 @RequiredArgsConstructor
@@ -34,5 +38,15 @@ public class CookieProvider {
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public String resolveCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/jwt/dto/ClaimsConvertible.java
+++ b/src/main/java/store/sonyk9919/api/global/jwt/dto/ClaimsConvertible.java
@@ -1,0 +1,8 @@
+package store.sonyk9919.api.global.jwt.dto;
+
+import java.util.Map;
+
+public interface ClaimsConvertible {
+    String getSubject();
+    Map<String, Object> getBody();
+}

--- a/src/main/java/store/sonyk9919/api/global/jwt/exception/JwtStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/jwt/exception/JwtStatus.java
@@ -1,0 +1,18 @@
+package store.sonyk9919.api.global.jwt.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtStatus implements BaseResponseStatus {
+    JWT_EXPIRY_REQUEST(HttpStatus.UNAUTHORIZED, "JWT-001", "만료된 요청입니다."),
+    JWT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "JWT-002", "유효하지 않은 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/global/jwt/service/JwtProvider.java
+++ b/src/main/java/store/sonyk9919/api/global/jwt/service/JwtProvider.java
@@ -1,0 +1,55 @@
+package store.sonyk9919.api.global.jwt.service;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.global.jwt.dto.ClaimsConvertible;
+import store.sonyk9919.api.global.jwt.exception.JwtStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+
+    public JwtProvider(@Value("${jwt.secret}") String key) {
+        secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(key));
+    }
+
+    public String createJwt(Claims claims, long expirationMs) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .claims(claims)
+                .signWith(secretKey)
+                .issuedAt(now)
+                .expiration(expiration)
+                .compact();
+    }
+
+    public Claims createClaims(ClaimsConvertible convertible) {
+        return Jwts.claims()
+                .subject(convertible.getSubject())
+                .add(convertible.getBody())
+                .build();
+    }
+
+    public Claims parseJwt(String jwt) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(jwt)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(JwtStatus.JWT_EXPIRY_REQUEST);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new CustomException(JwtStatus.JWT_BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -48,3 +48,6 @@ file:
 analysis:
   fastApi:
     url: ${custom.dev.fastApiUrl:http://localhost:8989}
+
+jwt:
+  secret: ${custom.security.jwt.secret:ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,3 +51,16 @@ analysis:
 
 jwt:
   secret: ${custom.security.jwt.secret:ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=}
+
+security:
+  cors:
+    origins:
+      - http://localhost:3000
+    methods:
+      - GET
+      - POST
+      - OPTIONS
+    headers:
+      - "*"
+    path: /**
+    maxAge: 3600

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,6 @@ file:
 analysis:
   fastApi:
     url: ${custom.prod.fastApiUrl}
+
+jwt:
+  secret: ${custom.jwt.secret}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,3 +23,16 @@ analysis:
 
 jwt:
   secret: ${custom.jwt.secret}
+
+security:
+  cors:
+    origins:
+      - https://sonyk9919.store
+    methods:
+      - GET
+      - POST
+      - OPTIONS
+    headers:
+      - Content-Type
+    path: /**
+    maxAge: 3600

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,8 +23,14 @@ analysis:
 
 jwt:
   secret: ${custom.jwt.secret}
+  expiry:
+    access: 3600
 
 security:
+  cookie:
+    sameSite: Lax
+    domain: .sonyk9919.store
+
   cors:
     origins:
       - https://sonyk9919.store

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -19,6 +19,10 @@ custom:
 
   sse:
     timeout: NEED_TO_INPUT # e.g 300000 -> 5 min
+
   cache:
     analysis:
       ttl: NEED_TO_INPUT  # e.g 5m -> 5 min
+
+  jwt:
+    secret: NEED_TO_INPUT

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,16 +1,11 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:./db_dev;MODE=MySQL;AUTO_SERVER=TRUE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     username: sa
     password:
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-      settings:
-        web-allow-others: true
 
   sql:
     init:
@@ -23,34 +18,25 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    defer-datasource-initialization: true
+    show-sql: true
     properties:
       hibernate:
         format_sql: true
-        highlight_sql: true
-        use_sql_comments: true
-    defer-datasource-initialization: true
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 logging:
   level:
     org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.hibernate.orm.jdbc.extract: TRACE
-    org.springframework.transaction.interceptor: TRACE
 
 file:
-  upload-dir: ${custom.dev.uploadDir:./upload/}
+  upload-dir: ./upload/
 
 analysis:
   fastApi:
-    url: ${custom.dev.fastApiUrl:http://localhost:8989}
+    url: http://localhost:8989
 
 jwt:
-  secret: ${custom.security.jwt.secret:ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=}
+  secret: ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=
   expiry:
     access: 3600
 

--- a/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
@@ -1,0 +1,81 @@
+package store.sonyk9919.api.domain.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.auth.dto.AuthDto;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthE2ETest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입부터 로그인까지의 전체 흐름을 검증한다")
+    void authFlowTest() throws Exception {
+        String id = "testUser";
+        String password = "password123!";
+        AuthDto authDto = AuthDto.from(id, password);
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authDto)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authDto)))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.SET_COOKIE))
+                .andExpect(result -> {
+                    String setCookie = result.getResponse().getHeader(HttpHeaders.SET_COOKIE);
+                    assertThat(setCookie).contains("accessToken");
+                    assertThat(setCookie).contains("HttpOnly");
+                    assertThat(setCookie).contains("Secure");
+                });
+    }
+
+    @TestConfiguration
+    public static class TestConfig {
+
+        @Bean
+        @Primary
+        public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) {
+            httpSecurity
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                    .authorizeHttpRequests(auth -> auth
+                            .anyRequest().permitAll()
+                    )
+                    .formLogin(AbstractHttpConfigurer::disable)
+                    .httpBasic(AbstractHttpConfigurer::disable);
+            return httpSecurity.build();
+        }
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
@@ -1,5 +1,7 @@
 package store.sonyk9919.api.domain.auth;
 
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,12 +17,17 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.auth.dto.AuthDto;
+import store.sonyk9919.api.domain.auth.filter.JwtAuthenticationFilter;
+import store.sonyk9919.api.domain.member.entitiy.AccountRole;
 import tools.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,7 +43,7 @@ public class AuthE2ETest {
     private ObjectMapper objectMapper;
 
     @Test
-    @DisplayName("회원가입부터 로그인까지의 전체 흐름을 검증한다")
+    @DisplayName("회원가입부터 로그인, 권한이 부여된 API 요청까지의 전체 흐름을 검증한다")
     void authFlowTest() throws Exception {
         String id = "testUser";
         String password = "password123!";
@@ -47,7 +54,7 @@ public class AuthE2ETest {
                         .content(objectMapper.writeValueAsString(authDto)))
                 .andExpect(status().isCreated());
 
-        mockMvc.perform(post("/auth/login")
+        MvcResult mvcResult = mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(authDto)))
                 .andExpect(status().isOk())
@@ -57,11 +64,22 @@ public class AuthE2ETest {
                     assertThat(setCookie).contains("accessToken");
                     assertThat(setCookie).contains("HttpOnly");
                     assertThat(setCookie).contains("Secure");
-                });
+                })
+                .andReturn();
+
+        Cookie[] cookies = mvcResult.getResponse().getCookies();
+        mockMvc.perform(get("/auth/test/user").cookie(cookies))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/auth/test/admin").cookie(cookies))
+                .andExpect(status().isForbidden());
     }
 
     @TestConfiguration
+    @RequiredArgsConstructor
     public static class TestConfig {
+
+        private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
         @Bean
         @Primary
@@ -71,10 +89,13 @@ public class AuthE2ETest {
                     .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                     .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                     .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/auth/test/user").hasAuthority(AccountRole.USER.getKey())
+                            .requestMatchers("/auth/test/admin").hasAuthority(AccountRole.ADMIN.getKey())
                             .anyRequest().permitAll()
                     )
                     .formLogin(AbstractHttpConfigurer::disable)
-                    .httpBasic(AbstractHttpConfigurer::disable);
+                    .httpBasic(AbstractHttpConfigurer::disable)
+                    .addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
             return httpSecurity.build();
         }
     }

--- a/src/test/java/store/sonyk9919/api/domain/auth/controller/AuthMemberMembershipTestController.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/controller/AuthMemberMembershipTestController.java
@@ -1,0 +1,45 @@
+package store.sonyk9919.api.domain.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import store.sonyk9919.api.domain.auth.dto.AuthDto;
+import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
+import store.sonyk9919.api.domain.auth.service.AuthLoginFacade;
+import store.sonyk9919.api.domain.member.service.MemberAccountService;
+import store.sonyk9919.api.global.cookie.CookieProvider;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthMemberMembershipTestController {
+
+    private final AuthLoginFacade authLoginFacade;
+    private final CookieProvider cookieProvider;
+    private final MemberAccountService memberAccountService;
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void register(@RequestBody AuthDto authDto) {
+        memberAccountService.createMemberAccount(authDto.getName(), authDto.getPassword());
+    }
+
+    @PostMapping(value = "/login")
+    @ResponseStatus(HttpStatus.OK)
+    public void login(@RequestBody AuthDto authDto, HttpServletResponse response) {
+        List<TokenResponseDto> tokens = authLoginFacade.login(
+                authDto.getName(),
+                authDto.getPassword()
+        );
+
+        tokens.forEach(token -> cookieProvider.addCookie(
+                response,
+                token.getName(),
+                token.getToken(),
+                token.getExpiry()
+        ));
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/auth/controller/AuthMemberMembershipTestController.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/controller/AuthMemberMembershipTestController.java
@@ -42,4 +42,12 @@ public class AuthMemberMembershipTestController {
                 token.getExpiry()
         ));
     }
+
+    @GetMapping("/test/user")
+    @ResponseStatus(HttpStatus.OK)
+    public void user() {}
+
+    @GetMapping("/test/admin")
+    @ResponseStatus(HttpStatus.OK)
+    public void admin() {}
 }

--- a/src/test/java/store/sonyk9919/api/domain/auth/dto/AuthDto.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/dto/AuthDto.java
@@ -1,0 +1,23 @@
+package store.sonyk9919.api.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthDto {
+
+    private String name;
+    private String password;
+
+    private AuthDto(String name, String password) {
+        this.name = name;
+        this.password = password;
+    }
+
+    public static AuthDto from(String name, String password) {
+        return new AuthDto(name, password);
+    }
+
+}

--- a/src/test/java/store/sonyk9919/api/global/jwt/service/JwtProviderTest.java
+++ b/src/test/java/store/sonyk9919/api/global/jwt/service/JwtProviderTest.java
@@ -1,0 +1,90 @@
+package store.sonyk9919.api.global.jwt.service;
+
+import io.jsonwebtoken.Claims;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import store.sonyk9919.api.global.jwt.dto.ClaimsConvertible;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    public void setUp() {
+        jwtProvider = new JwtProvider("ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=");
+    }
+
+    @Test
+    @DisplayName("토큰의 발급과 추출이 정상적으로 수행되어야 함")
+    public void createJwt() {
+        User user = User.from(0L, "son", 28);
+        Claims fromUser = jwtProvider.createClaims(user);
+        String jwt = jwtProvider.createJwt(fromUser, 10 * 1000);
+        Claims fromJwt = jwtProvider.parseJwt(jwt);
+
+        assertThat(fromJwt.getSubject()).isEqualTo(fromUser.getSubject());
+        assertThat(fromJwt.get(User.ClaimsKey.NAME.getKey())).isEqualTo(fromUser.get(User.ClaimsKey.NAME.getKey()));
+        assertThat(fromJwt.get(User.ClaimsKey.AGE.getKey())).isEqualTo(fromUser.get(User.ClaimsKey.AGE.getKey()));
+    }
+
+    @Test
+    @DisplayName("만료된 토큰을 추출할 경우 에러가 발생해야 함")
+    public void expireJwt() {
+        User user = User.from(0L, "son", 28);
+        Claims fromUser = jwtProvider.createClaims(user);
+        String jwt = jwtProvider.createJwt(fromUser, -1 * 1000);
+        assertThatThrownBy(() -> jwtProvider.parseJwt(jwt)).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("변조된 토큰을 추출할 경우 에러가 발생해야 함")
+    public void invalidJwt() {
+        User user = User.from(0L, "son", 28);
+        Claims fromUser = jwtProvider.createClaims(user);
+        String jwt = jwtProvider.createJwt(fromUser, 10 * 1000);
+        assertThatThrownBy(() -> jwtProvider.parseJwt(jwt + "invalid")).isInstanceOf(CustomException.class);
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class User implements ClaimsConvertible {
+
+        private final Long id;
+        private final String name;
+        private final int age;
+
+        public static User from(Long id, String name, int age) {
+            return new User(id, name, age);
+        }
+
+        @Override
+        public String getSubject() {
+            return String.valueOf(id);
+        }
+
+        @Override
+        public Map<String, Object> getBody() {
+            return Map.of(
+                    ClaimsKey.NAME.getKey(), name,
+                    ClaimsKey.AGE.getKey(), age
+            );
+        }
+
+        @Getter
+        @RequiredArgsConstructor
+        public enum ClaimsKey {
+            NAME("name"),
+            AGE("age");
+
+            private final String key;
+        }
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

### Feature
- 인증/인가를 위한 MemberAcount 엔티티를 추가하였습니다.
- Jwt기반의 인증/인가 시스템을 추가하였습니다. 

### Chore
- Jwt, Spring-securty 의존성을 추가하였습니다.
- 테스트용 설정파일을 추가하였습니다. (e.g. `application-test.yml`)

### Test
- 회원가입, 로그인, 권한이 부여된 API 요청까지 E2E 테스트를 추가하였습니다.

## 상세 설명

- 인증/인가 기능 추가 과정에서 기본적으로 사용자의 아이디/비밀번호/역할에 대한 엔티티가 필요해서 간단히 구성했습니다.
- RefreshToken 까지 추가하기엔 호흡이 좀 길어져서 리뷰하시는 것도 힘드실 것 같고, 다른 PR에서 Redis 의존성이 걸려있기 때문에 추후 추가할 예정입니다.

## 체크리스트

- [x] Jwt 기반의 인증/인가
- [x] E2E 테스트
- [ ] RefreshToken 전략

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-149

## 참고사항

- Spring Security에 대해서 정리한 문서입니다. 
  - https://www.notion.so/Spring-Security-w-JWT-2fd9e82c888c8076b119ec038c21faed
  - session -> jwt -> redis -> OAuth -> 2FA 순으로 진행되니 읽어보시면 인사이트를 좀 얻어가실 수 있지 않을까 싶네요. :)  