### PR TITLE
chore: jenkins 연동

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk-alpine AS build
+WORKDIR /trash
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+
+RUN chmod +x gradlew
+
+RUN ./gradlew dependencies --no-daemon
+
+COPY src src
+RUN ./gradlew clean bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /trash
+
+COPY --from=build /trash/build/libs/*.jar trash.jar
+
+ENTRYPOINT ["java", "-jar", "trash.jar"]
+EXPOSE 8080

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,10 @@ pipeline {
         }
 
         stage('Deploy') {
+            when {
+                branch 'develop'
+            }
+
             steps {
                 withCredentials([
                         string(credentialsId: 'DBPW', variable: 'DB_PASSWORD'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Test & Build') {
+            steps {
+                sh 'chmod +x gradlew'
+                sh './gradlew clean bootJar'
+            }
+        }
+
+        stage('Deploy') {
+            steps {
+                withCredentials([
+                        string(credentialsId: 'DBPW', variable: 'DB_PASSWORD'),
+                        file(credentialsId: 'SECRET_YML', variable: 'SECRET_YML')
+                ]) {
+                    sh "cp ${SECRET_YML} ./src/main/resources/application-secret.yml"
+                    sh """
+                        SPRING_PROFILE=${env.APP_PROD_PROFILE} \
+                        APP_PORT=${env.APP_PROD_PORT} \
+                        DB_PORT=${env.DB_PROD_PORT} \
+                        REDIS_PORT=${env.REDIS_PROD_PORT} \
+                        DB_NAME=${env.DB_NAME} \
+                        IMAGE_PATH=${env.IMAGE_PATH_FROM_SPRING}\
+                        DB_PASSWORD='${DB_PASSWORD}' \
+                        docker compose up -d --build
+                    """
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       timeout: 5s
       retries: 10
     restart: always
+    networks:
+      - trash-bridge
 
   trash-redis:
     image: redis:latest
@@ -22,6 +24,8 @@ services:
     ports:
       - "${REDIS_PORT}:6379"
     restart: always
+    networks:
+      - trash-bridge
 
   trash-app:
     build: .
@@ -37,3 +41,10 @@ services:
       - TZ=Asia/Seoul
     volumes:
       - ${IMAGE_PATH}:${IMAGE_PATH}
+    restart: always
+    networks:
+      - trash-bridge
+
+networks:
+  trash-bridge:
+    name: trash-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  trash-db:
+    image: mysql:8.0
+    container_name: trash-db
+    ports:
+      - "${DB_PORT}:3306"
+    environment:
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_OPTS="--default-time-zone=+09:00"
+    volumes:
+      - /home/github/trash/mysql_data:/var/lib/mysql
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      timeout: 5s
+      retries: 10
+    restart: always
+
+  trash-redis:
+    image: redis:latest
+    container_name: trash-redis
+    ports:
+      - "${REDIS_PORT}:6379"
+    restart: always
+
+  trash-app:
+    build: .
+    container_name: trash-app
+    ports:
+      - "${APP_PORT}:8080"
+    depends_on:
+      trash-db:
+        condition: service_healthy
+    environment:
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILE}
+      - IMAGE_UPLOAD_PATH=${IMAGE_PATH}
+      - TZ=Asia/Seoul
+    volumes:
+      - ${IMAGE_PATH}:${IMAGE_PATH}

--- a/src/main/java/store/sonyk9919/api/domain/disposal/entity/TrashDisposal.java
+++ b/src/main/java/store/sonyk9919/api/domain/disposal/entity/TrashDisposal.java
@@ -15,6 +15,6 @@ public class TrashDisposal {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String guide;
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -42,3 +42,9 @@ security:
       - Content-Type
     path: /**
     maxAge: 3600
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,10 +9,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-  data:
-    redis:
-      host: ${custom.prod.redis.host}
-      port: ${custom.prod.redis.port}
 
 file:
   upload-dir: ${custom.prod.uploadDir}
@@ -33,10 +29,14 @@ security:
 
   cors:
     origins:
-      - https://sonyk9919.store
+      - https://sonyk9919.store:20024
+      - http://localhost:3000
+      - http://localhost:5173
     methods:
       - GET
       - POST
+      - DELETE
+      - PUT
       - OPTIONS
     headers:
       - Content-Type

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,7 +8,11 @@ spring:
       auto-commit: false
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
+  data:
+    redis:
+      host: ${custom.prod.redis.host}
+      port: ${custom.prod.redis.port}
 
 file:
   upload-dir: ${custom.prod.uploadDir}


### PR DESCRIPTION
## 주요 변경사항

### Feature

- CI/CD를 위해 아래와 같은 파일을 작성하였습니다.
  - Jenkinsfile
  - Dockerfile
  - docker-compose.yml 

### Chore

- 서버가 정상적으로 배포되었는지 테스트를 위해 actuator 의존성을 추가하였습니다. 
  -  https://sonyk9919.store:20024/api/actuator/health

## 상세 설명

- Github Workflow 대신 Jenkins를 서버에 설치하여 CI/CD 파이프라인을 구축했습니다.
- 이제 develop 브랜치로 병합되는 변경사항은 정상적으로 배포될 경우 아래 경로를 통해 접근가능합니다.
  - https://sonyk9919.store:20024/api/**
- https://sonyk9919.store:20024/jenkins 에서 Jenkins 파이프라인이 수행되는 과정을 확인할 수 있습니다.
  - Jenkins 계정 정보는 Jira 테스크에 있는 노션에서 확인가능합니다.
- 무중단 배포나 Health 체크는 추후 추가 해볼생각입니다.

## 체크리스트

- [x] CI/CD 파이프라인 테스트
- [ ] 무중단 배포
- [ ] Health 체크 

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-163

## 참고사항

- Jira 테스크에 노션이 첨부되어 있으므로 확인 부탁드립니다!
