### PR TITLE
fix: 분석 상태 도입 및 SSE 타임아웃 예외처리

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisProgress.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisProgress.java
@@ -1,0 +1,7 @@
+package store.sonyk9919.api.domain.analysis.entity;
+
+public enum AnalysisProgress {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/entity/AnalysisRequest.java
@@ -24,11 +24,20 @@ public class AnalysisRequest extends BaseEntity {
     @Column(name = "request_id", nullable = false, unique = true)
     private String requestId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnalysisProgress state;
+
     private AnalysisRequest(String requestId) {
         this.requestId = requestId;
+        this.state = AnalysisProgress.PENDING;
     }
 
     public static AnalysisRequest createWithUUID() {
         return new AnalysisRequest(UUID.randomUUID().toString());
+    }
+
+    public void updateState(AnalysisProgress progress){
+        this.state = progress;
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisRequestService.java
@@ -3,6 +3,7 @@ package store.sonyk9919.api.domain.analysis.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisProgress;
 import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
 import store.sonyk9919.api.domain.analysis.exception.AnalysisStatus;
 import store.sonyk9919.api.domain.analysis.repository.AnalysisRequestRepository;
@@ -19,6 +20,12 @@ public class AnalysisRequestService {
         requestRepository.save(request);
 
         return request.getRequestId();
+    }
+
+    @Transactional
+    public void updateAnalysisProgress(String requestId, AnalysisProgress progress) {
+        AnalysisRequest request = getByRequestId(requestId);
+        request.updateState(progress);
     }
 
     public AnalysisRequest getByRequestId(String requestId) {

--- a/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
@@ -36,7 +36,7 @@ public class AnalysisResultNotifier {
         switch (request.getState()){
             case PENDING -> {return;}
             case FAILED -> {
-                notifyError(requestId, ErrorStatus.INTERNAL_SERVER_ERROR);
+                sseResultSender.sendError(requestId, ErrorStatus.INTERNAL_SERVER_ERROR);
                 return;
             }
         }

--- a/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
@@ -33,12 +33,12 @@ public class AnalysisResultNotifier {
     public void notifyIfAlreadyCompleted(String requestId) {
         AnalysisRequest request = analysisRequestService.getByRequestId(requestId);
 
-        switch (request.getState()){
-            case PENDING -> {return;}
-            case FAILED -> {
-                sseResultSender.sendError(requestId, ErrorStatus.INTERNAL_SERVER_ERROR);
-                return;
-            }
+        if(request.getState() == AnalysisProgress.PENDING) {
+            return;
+        }
+        if(request.getState() == AnalysisProgress.FAILED){
+            sseResultSender.sendError(requestId, ErrorStatus.INTERNAL_SERVER_ERROR);
+            return;
         }
 
         TrashResultDto saved = trashService.fetchSavedItemsByRequestId(requestId);

--- a/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/service/AnalysisResultNotifier.java
@@ -2,7 +2,10 @@ package store.sonyk9919.api.domain.analysis.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.analysis.dto.AnalysisResponseDto;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisProgress;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
 import store.sonyk9919.api.domain.sse.service.SseResultSender;
 import store.sonyk9919.api.domain.trash.dto.TrashResultDto;
 import store.sonyk9919.api.domain.trash.service.TrashService;
@@ -13,20 +16,32 @@ import store.sonyk9919.api.global.common.dto.ErrorStatus;
 public class AnalysisResultNotifier {
     private final TrashService trashService;
     private final SseResultSender sseResultSender;
+    private final AnalysisRequestService analysisRequestService;
 
+    @Transactional
     public void saveAndNotify(String requestId, AnalysisResponseDto result) {
         TrashResultDto saved = trashService.saveDetectedItems(requestId, result);
+        analysisRequestService.updateAnalysisProgress(requestId, AnalysisProgress.COMPLETED);
         sseResultSender.sendSuccess(requestId, saved);
     }
 
     public void notifyError(String requestId, ErrorStatus status) {
+        analysisRequestService.updateAnalysisProgress(requestId, AnalysisProgress.FAILED);
         sseResultSender.sendError(requestId, status);
     }
 
     public void notifyIfAlreadyCompleted(String requestId) {
-        TrashResultDto saved = trashService.fetchSavedItemsByRequestId(requestId);
-        if (saved.isEmptyItems()) return;
+        AnalysisRequest request = analysisRequestService.getByRequestId(requestId);
 
+        switch (request.getState()){
+            case PENDING -> {return;}
+            case FAILED -> {
+                notifyError(requestId, ErrorStatus.INTERNAL_SERVER_ERROR);
+                return;
+            }
+        }
+
+        TrashResultDto saved = trashService.fetchSavedItemsByRequestId(requestId);
         sseResultSender.sendSuccess(requestId, saved);
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import store.sonyk9919.api.global.common.dto.BaseResponse;
 import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 import store.sonyk9919.api.global.common.dto.ErrorStatus;
@@ -54,6 +55,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
         log.warn("Method Not Allowed at {}: {}", request.getRequestURI(), e.getMessage());
         return BaseResponse.error(ErrorStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public void  handleAsyncRequestTimeout(AsyncRequestTimeoutException e) {
+        log.warn("SSE connection timeout: {}", e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION

## 주요 변경사항
-  분석 결과가 빈값이면 타임아웃까지 기다리는 문제를 분석 상태를 도입해 수정
- SSE 타임아웃 시 발생하는 예외 AsyncRequestTimeoutException를 핸들러에 추가

### Feature
- AnalysisProgress로 상태 추가 (pending, completed, failed)

### Chore
- sse timeout 시 `AsyncRequestTimeoutException` 에외가 발생되는데 `GlobalExceptionHandler` 에 따로 명시되어 있지 않아 추가했습니다.

## 상세 설명

- 이전 분석이 완료되었는데도 detected_items가 빈값이면 `if (saved.isEmptyItems()) return;` 으로 반환 시켜 sse timeout까지 기다리는 문제를 AnalysisRequest에 state 필드로 분석의 상태 필드를 추가해 분석 상태에 맞게 바로 반환하고 상태를 추적할 수 있도록 수정했습니다.


## 체크리스트

- [x] 분석이 빈 값인 경우 빈 결과를 반환



## 참고사항

- 상태 별 의미(AnalysisProgress)
```
PENDING  -> 아직 분석 중, SSE 대기
COMPLETED -> 저장된 결과 즉시 전송
FAILED   -> 에러 응답 즉시 전송
```