### PR TITLE
chore: RabbitMQ 환경 설정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,10 @@ pipeline {
                         DB_NAME=${env.DB_NAME} \
                         IMAGE_PATH=${env.IMAGE_PATH_FROM_SPRING}\
                         DB_PASSWORD='${DB_PASSWORD}' \
+                        RABBITMQ_PORT=${env.RABBITMQ_PROD_PORT} \
+                        RABBITMQ_MANAGEMENT_PORT=${env.RABBITMQ_MANAGEMENT_PROD_PORT} \
+                        RABBITMQ_USERNAME=${env.RABBITMQ_PROD_USERNAME} \
+                        RABBITMQ_PASSWORD=${env.RABBITMQ_PROD_PASSWORD} \
                         docker compose up -d --build
                     """
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -59,13 +59,17 @@ dependencies {
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	// Test
+    // RabbitMQ
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-amqp-test'
 }
 
 tasks.named('test') {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,10 @@
+services:
+  trash-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: trash-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: test
+      RABBITMQ_DEFAULT_PASS: 1234
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,22 @@ services:
     networks:
       - trash-bridge
 
+  trash-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: trash-rabbitmq
+    ports:
+      - "${RABBITMQ_PORT}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT}:15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_USERNAME}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
+    healthcheck:
+      test: [ "CMD", "rabbitmq-diagnostics", "ping" ]
+      timeout: 5s
+      retries: 10
+    networks:
+      - trash-bridge
+
   trash-app:
     build: .
     container_name: trash-app
@@ -35,9 +51,13 @@ services:
     depends_on:
       trash-db:
         condition: service_healthy
+      trash-rabbitmq:
+        condition: service_healthy
     environment:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILE}
       - IMAGE_UPLOAD_PATH=${IMAGE_PATH}
+      - RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
+      - RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
       - TZ=Asia/Seoul
     volumes:
       - ${IMAGE_PATH}:${IMAGE_PATH}

--- a/src/main/java/store/sonyk9919/api/global/config/RabbitMQConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/RabbitMQConfig.java
@@ -1,0 +1,64 @@
+package store.sonyk9919.api.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import store.sonyk9919.api.global.config.property.RabbitMQProperty;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+    private final RabbitMQProperty property;
+
+    @Bean
+    public Queue requestQueue(){
+        return new Queue(property.getRequestQueueName());
+    }
+
+    @Bean
+    public Queue resultQueue(){
+        return new Queue(property.getResultQueueName());
+    }
+
+    @Bean
+    public TopicExchange exchange(){
+        return new TopicExchange(property.getExchange());
+    }
+
+    @Bean
+    public Binding requestBinding(){
+        return BindingBuilder
+                .bind(requestQueue())
+                .to(exchange())
+                .with(property.getRequestRoutingKey());
+    }
+
+    @Bean
+    public Binding resultBinding(){
+        return BindingBuilder
+                .bind(resultQueue())
+                .to(exchange())
+                .with(property.getResultRoutingKey());
+    }
+
+    @Bean
+    public MessageConverter converter(){
+        return new JacksonJsonMessageConverter();
+    }
+
+    @Bean
+    public AmqpTemplate amqpTemplate(ConnectionFactory connectionFactory){
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(converter());
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/property/RabbitMQProperty.java
+++ b/src/main/java/store/sonyk9919/api/global/config/property/RabbitMQProperty.java
@@ -1,0 +1,17 @@
+package store.sonyk9919.api.global.config.property;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "rabbitmq")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RabbitMQProperty {
+    private final String requestQueueName;
+    private final String resultQueueName;
+    private final String exchange;
+    private final String requestRoutingKey;
+    private final String resultRoutingKey;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,6 +31,12 @@ spring:
         use_sql_comments: true
     defer-datasource-initialization: true
 
+  rabbitmq:
+    host: ${custom.dev.rabbitmq.host:localhost}
+    port: 5672
+    username: ${custom.dev.rabbitmq.username:test}
+    password: ${custom.dev.rabbitmq.password:1234}
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,12 @@ spring:
     hibernate:
       ddl-auto: create
 
+  rabbitmq:
+    host: ${custom.prod.rabbitmq.host}
+    port: ${custom.prod.rabbitmq.port}
+    username: ${custom.prod.rabbitmq.username}
+    password: ${custom.prod.rabbitmq.password}
+
 file:
   upload-dir: ${custom.prod.uploadDir}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,5 +36,10 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-
+rabbitmq:
+  request-queue-name: analysis.request.queue
+  result-queue-name: analysis.result.queue
+  exchange: analysis.exchange
+  request-routing-key: analysis.request
+  result-routing-key: analysis.result
 


### PR DESCRIPTION
## 주요 변경사항

- spring에 기본 rabbitmq를 설정과 인프라를 위한 도커파일에 rabbitmq 환경 변수 설정을 진행했습니다.

### Feature
- 로컬에 rabbitmq가 없어도 docker-compose-dev.yml 에서 rabbitmq 실행할 수 있게 작성

### Chore
- `docker-compose.yml`에 `trash-rabbitmq` 서비스 추가
- Jenkinsfile 및 applicatoin yml 파일에 환경 변수 설정
- `RabbitMQConfig` 작성 (queue 2개, exchange, Binding 키, converter 빈 등록)
- converter는 JSON 직렬화를 위한 JacksonJsonMessageConverter을 빈으로 등록

## 상세 설명

- RabbitMQ 큐는 총 2개로 구성된다.
  - `analysis.request.queue` : Spring 서버에서 FastAPI로 분석 요청을 전송하는 큐 (spring기준 Producer)
  - `analysis.result.queue` : FastAPI에서 분석 결과를 Spring 서버로 전달받는 큐 (spring기준 Consumer)
- 두 큐는 `analysis.exchange`(Broker)에 각각 `analysis.request`, `analysis.result` 라우팅 키로 바인딩된다.

## 체크리스트
- [x] RabbitMQ 관리자 페이지(15672 포트) 접속 확인 및 익스체인지/큐 생성 여부 확인

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-169

## 참고사항
- 약간의 도움이 될 수 있도록 Jira에 정리한 [노션 페이지](https://www.notion.so/RabbitMQ-in-Spring-317489b07a8c80c5bc08f9d28348a5eb?source=copy_link)를 첨부했습니다.
- fastapi에도 구현이 필요한 producer, consumer 부분은 작성해서 fast-api-server-prototype에 따로 PR 올려봤습니다.
  - https://github.com/untitled-KGU/fast-api-server-prototype/pull/1


</br>

- docker-compose-dev.yml은 `docker-compose -f docker-compose-dev.yml up -d`로 실행할 수 있습니다.'
- 모니터링: `http://localhost:15672/` 에서 dashboard를 확인할 수 있습니다.

</br>

- Jenkins에 들어가서 수정에 맞게 application-secret.yml과 환경변수를 추가했습니다. 

