### PR TITLE
feat: refreshToken 전략

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //QueryDsl
     implementation "io.github.openfeign.querydsl:querydsl-jpa:6.11"
     annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:6.11:jpa"

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // Test Container
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter:2.0.2"
+    testImplementation "com.redis:testcontainers-redis:2.2.4"
     testImplementation 'org.springframework.boot:spring-boot-starter-amqp-test'
 }
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,3 +8,9 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+  trash-redis:
+    image: redis:latest
+    container_name: trash-redis
+    ports:
+      - "6379:6379"
+    restart: always

--- a/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenCookieName.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/dto/TokenCookieName.java
@@ -2,4 +2,5 @@ package store.sonyk9919.api.domain.auth.dto;
 
 public interface TokenCookieName {
     String ACCESS_TOKEN = "accessToken";
+    String REFRESH_TOKEN = "refreshToken";
 }

--- a/src/main/java/store/sonyk9919/api/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.dto.TokenCookieName;
+import store.sonyk9919.api.domain.auth.service.AuthTokenIssuer;
 import store.sonyk9919.api.global.common.exception.CustomException;
 import store.sonyk9919.api.global.cookie.CookieProvider;
 import store.sonyk9919.api.global.jwt.service.JwtProvider;
@@ -28,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final CookieProvider cookieProvider;
     private final JwtProvider jwtProvider;
     private final HandlerExceptionResolver handlerExceptionResolver;
+    private final AuthTokenIssuer authTokenIssuer;
 
     @Override
     protected void doFilterInternal(
@@ -36,15 +38,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         String accessToken = cookieProvider.resolveCookie(request, TokenCookieName.ACCESS_TOKEN);
+        String refreshToken = cookieProvider.resolveCookie(request, TokenCookieName.REFRESH_TOKEN);
 
         try {
             if (accessToken != null) {
                 Claims claims = jwtProvider.parseJwt(accessToken);
                 injectSecurityContext(AuthMemberDto.from(claims));
+            } else if (refreshToken != null) {
+                Claims claims = jwtProvider.parseJwt(refreshToken);
+                reissueAuthenticationToken(AuthMemberDto.from(claims), refreshToken, response);
             }
             filterChain.doFilter(request, response);
         } catch (CustomException e) {
             cookieProvider.expireCookie(response, TokenCookieName.ACCESS_TOKEN);
+            cookieProvider.expireCookie(response, TokenCookieName.REFRESH_TOKEN);
             handlerExceptionResolver.resolveException(request, response, null, e);
         }
 
@@ -55,5 +62,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(member, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void reissueAuthenticationToken(AuthMemberDto member, String refreshToken, HttpServletResponse response) {
+        authTokenIssuer.reissue(member, refreshToken)
+                .forEach(token ->
+                        cookieProvider.addCookie(response, token.getName(), token.getToken(), token.getExpiry()));
+        injectSecurityContext(member);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
@@ -18,7 +18,6 @@ public class AuthLoginFacade {
 
     public List<TokenResponseDto> login(String name, String password) {
         MemberAccount memberAccount = memberAccountService.getMemberAccount(name, password);
-
         return authTokenIssuer.issue(AuthMemberDto.from(memberAccount));
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
@@ -2,6 +2,7 @@ package store.sonyk9919.api.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
 import store.sonyk9919.api.domain.member.entitiy.MemberAccount;

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
@@ -20,13 +20,25 @@ public class AuthTokenIssuer {
     @Value("${jwt.expiry.access}")
     private long accessTokenExpiry;
 
+    @Value("${jwt.expiry.refresh}")
+    private long refreshTokenExpiry;
+
     public List<TokenResponseDto> issue(AuthMemberDto member) {
-        return List.of(issueAccessToken(member));
+        return List.of(
+                issueAccessToken(member),
+                issueRefreshToken(member)
+        );
     }
 
     private TokenResponseDto issueAccessToken(AuthMemberDto member) {
         Claims claims = jwtProvider.createClaims(member);
         String jwt = jwtProvider.createJwt(claims, accessTokenExpiry * 1000);
         return TokenResponseDto.from(TokenCookieName.ACCESS_TOKEN, jwt, accessTokenExpiry);
+    }
+
+    private TokenResponseDto issueRefreshToken(AuthMemberDto member) {
+        Claims claims = jwtProvider.createClaims(member);
+        String jwt = jwtProvider.createJwt(claims, refreshTokenExpiry * 1000);
+        return TokenResponseDto.from(TokenCookieName.REFRESH_TOKEN, jwt, refreshTokenExpiry);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.dto.TokenCookieName;
 import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
+import store.sonyk9919.api.domain.member.entitiy.RefreshToken;
 import store.sonyk9919.api.domain.member.service.RefreshTokenService;
 import store.sonyk9919.api.global.jwt.service.JwtProvider;
 
@@ -30,6 +31,21 @@ public class AuthTokenIssuer {
         TokenResponseDto refreshToken = createToken(member, TokenCookieName.REFRESH_TOKEN, refreshTokenExpiry);
         refreshTokenService.createRefreshToken(member.getId(), refreshToken.getToken(), refreshTokenExpiry);
         return List.of(accessToken, refreshToken);
+    }
+
+    public List<TokenResponseDto> reissue(AuthMemberDto member, String refreshToken) {
+        RefreshToken oldRefreshToken = refreshTokenService.getRefreshToken(member.getId(), refreshToken);
+        return switch (oldRefreshToken.getStatus()) {
+            case STALE -> List.of(createToken(member, TokenCookieName.ACCESS_TOKEN, accessTokenExpiry));
+            case ACTIVATE -> {
+                TokenResponseDto newRefreshToken = createToken(member, TokenCookieName.REFRESH_TOKEN, refreshTokenExpiry);
+                refreshTokenService.upsertRefreshToken(member.getId(), newRefreshToken.getToken(), refreshTokenExpiry);
+                yield List.of(
+                        createToken(member, TokenCookieName.ACCESS_TOKEN, accessTokenExpiry),
+                        newRefreshToken
+                );
+            }
+        };
     }
 
     private TokenResponseDto createToken(AuthMemberDto member, String name, Long expiry) {

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
@@ -26,7 +26,7 @@ public class AuthTokenIssuer {
 
     private TokenResponseDto issueAccessToken(AuthMemberDto member) {
         Claims claims = jwtProvider.createClaims(member);
-        String jwt = jwtProvider.createJwt(claims, accessTokenExpiry);
+        String jwt = jwtProvider.createJwt(claims, accessTokenExpiry * 1000);
         return TokenResponseDto.from(TokenCookieName.ACCESS_TOKEN, jwt, accessTokenExpiry);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthTokenIssuer.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.dto.TokenCookieName;
 import store.sonyk9919.api.domain.auth.dto.TokenResponseDto;
+import store.sonyk9919.api.domain.member.service.RefreshTokenService;
 import store.sonyk9919.api.global.jwt.service.JwtProvider;
 
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.List;
 public class AuthTokenIssuer {
 
     private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${jwt.expiry.access}")
     private long accessTokenExpiry;
@@ -24,21 +26,15 @@ public class AuthTokenIssuer {
     private long refreshTokenExpiry;
 
     public List<TokenResponseDto> issue(AuthMemberDto member) {
-        return List.of(
-                issueAccessToken(member),
-                issueRefreshToken(member)
-        );
+        TokenResponseDto accessToken = createToken(member, TokenCookieName.ACCESS_TOKEN, accessTokenExpiry);
+        TokenResponseDto refreshToken = createToken(member, TokenCookieName.REFRESH_TOKEN, refreshTokenExpiry);
+        refreshTokenService.createRefreshToken(member.getId(), refreshToken.getToken(), refreshTokenExpiry);
+        return List.of(accessToken, refreshToken);
     }
 
-    private TokenResponseDto issueAccessToken(AuthMemberDto member) {
+    private TokenResponseDto createToken(AuthMemberDto member, String name, Long expiry) {
         Claims claims = jwtProvider.createClaims(member);
-        String jwt = jwtProvider.createJwt(claims, accessTokenExpiry * 1000);
-        return TokenResponseDto.from(TokenCookieName.ACCESS_TOKEN, jwt, accessTokenExpiry);
-    }
-
-    private TokenResponseDto issueRefreshToken(AuthMemberDto member) {
-        Claims claims = jwtProvider.createClaims(member);
-        String jwt = jwtProvider.createJwt(claims, refreshTokenExpiry * 1000);
-        return TokenResponseDto.from(TokenCookieName.REFRESH_TOKEN, jwt, refreshTokenExpiry);
+        String jwt = jwtProvider.createJwt(claims, expiry * 1000);
+        return TokenResponseDto.from(name, jwt, expiry);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshToken.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshToken.java
@@ -1,0 +1,19 @@
+package store.sonyk9919.api.domain.member.entitiy;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshToken {
+
+    private Long memberId;
+    private String token;
+    private Long expiry;
+    private RefreshTokenStatus status;
+
+    public static RefreshToken from(Long memberId, String token, Long expiry, RefreshTokenStatus status) {
+        return new RefreshToken(memberId, token, expiry, status);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshToken.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshToken.java
@@ -3,8 +3,10 @@ package store.sonyk9919.api.domain.member.entitiy;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RefreshToken {
 

--- a/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshTokenStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entitiy/RefreshTokenStatus.java
@@ -1,0 +1,16 @@
+package store.sonyk9919.api.domain.member.entitiy;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RefreshTokenStatus {
+    ACTIVATE("ACTIVATE"),
+    STALE("STALE");
+
+    private final String key;
+
+    @Override
+    public String toString() {
+        return key;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
@@ -10,7 +10,8 @@ import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 public enum MemberStatus implements BaseResponseStatus {
     MEMBER_ACCOUNT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER-001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     MEMBER_ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER-002", "잘 못 된 요청입니다."),
-    REFRESH_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REFRESH_TOKEN-001", "서버 내부 오류가 발생했습니다.");
+    REFRESH_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REFRESH_TOKEN-001", "서버 내부 오류가 발생했습니다."),
+    REFRESH_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN-002", "만료된 요청 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
@@ -9,7 +9,8 @@ import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 @RequiredArgsConstructor
 public enum MemberStatus implements BaseResponseStatus {
     MEMBER_ACCOUNT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER-001", "아이디 또는 비밀번호가 일치하지 않습니다."),
-    MEMBER_ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER-002", "잘 못 된 요청입니다.");
+    MEMBER_ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER-002", "잘 못 된 요청입니다."),
+    REFRESH_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REFRESH_TOKEN-001", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/repository/RefreshTokenRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 import store.sonyk9919.api.domain.member.entitiy.RefreshToken;
+import store.sonyk9919.api.domain.member.entitiy.RefreshTokenStatus;
 import store.sonyk9919.api.domain.member.exception.MemberStatus;
 import store.sonyk9919.api.global.common.exception.CustomException;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class RefreshTokenRepository {
     private final Long GRACE_PERIOD = 5L;
 
     private final RedisScript<Boolean> clearMemberRefreshTokens;
+    private final RedisScript<Boolean> rotateRefreshToken;
     private final ObjectMapper objectMapper;
 
     private String refreshTokenKey(Long memberId) {
@@ -49,6 +53,40 @@ public class RefreshTokenRepository {
                     refreshToken.getToken(),
                     objectMapper.writeValueAsString(refreshToken),
                     String.valueOf(refreshToken.getExpiry())
+            );
+        } catch (Exception e) {
+            throw new CustomException(MemberStatus.REFRESH_TOKEN_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public Optional<RefreshToken> findBy(Long memberId, String token) {
+        String jsonString = (String) redisTemplate.opsForValue().get(refreshTokenKey(memberId, token));
+
+        if (jsonString == null) return Optional.empty();
+        try {
+            RefreshToken refreshToken = objectMapper.readValue(jsonString, RefreshToken.class);
+            return Optional.of(refreshToken);
+        } catch (JacksonException e) {
+            throw new CustomException(MemberStatus.REFRESH_TOKEN_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void upsert(RefreshToken refreshToken) {
+        List<String> keys = List.of(
+                refreshTokenKey(refreshToken.getMemberId()),
+                refreshTokenIndexKey(refreshToken.getMemberId()),
+                refreshTokenKey(refreshToken.getMemberId(), refreshToken.getToken())
+        );
+
+        try {
+            redisTemplate.execute(
+                    rotateRefreshToken,
+                    keys,
+                    refreshToken.getToken(),
+                    objectMapper.writeValueAsString(refreshToken),
+                    String.valueOf(refreshToken.getExpiry()),
+                    RefreshTokenStatus.STALE.toString(),
+                    String.valueOf(GRACE_PERIOD)
             );
         } catch (Exception e) {
             throw new CustomException(MemberStatus.REFRESH_TOKEN_INTERNAL_SERVER_ERROR);

--- a/src/main/java/store/sonyk9919/api/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,57 @@
+package store.sonyk9919.api.domain.member.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Repository;
+import store.sonyk9919.api.domain.member.entitiy.RefreshToken;
+import store.sonyk9919.api.domain.member.exception.MemberStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final String REFRESH_TOKEN_PREFIX = "RT";
+    private final String INDEX_PREFIX = "INDEX";
+    private final Long GRACE_PERIOD = 5L;
+
+    private final RedisScript<Boolean> clearMemberRefreshTokens;
+    private final ObjectMapper objectMapper;
+
+    private String refreshTokenKey(Long memberId) {
+        return REFRESH_TOKEN_PREFIX + ":" + memberId;
+    }
+
+    private String refreshTokenKey(Long memberId, String token) {
+        return REFRESH_TOKEN_PREFIX + ":" + memberId + ":" + token;
+    }
+
+    private String refreshTokenIndexKey(Long memberId) {
+        return REFRESH_TOKEN_PREFIX + ":" + INDEX_PREFIX + ":" + memberId;
+    }
+
+    public void save(RefreshToken refreshToken) {
+        List<String> keys = List.of(
+                refreshTokenKey(refreshToken.getMemberId()),
+                refreshTokenIndexKey(refreshToken.getMemberId()),
+                refreshTokenKey(refreshToken.getMemberId(), refreshToken.getToken())
+        );
+
+        try {
+            redisTemplate.execute(
+                    clearMemberRefreshTokens,
+                    keys,
+                    refreshToken.getToken(),
+                    objectMapper.writeValueAsString(refreshToken),
+                    String.valueOf(refreshToken.getExpiry())
+            );
+        } catch (Exception e) {
+            throw new CustomException(MemberStatus.REFRESH_TOKEN_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/RefreshTokenService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import store.sonyk9919.api.domain.member.entitiy.RefreshToken;
 import store.sonyk9919.api.domain.member.entitiy.RefreshTokenStatus;
+import store.sonyk9919.api.domain.member.exception.MemberStatus;
 import store.sonyk9919.api.domain.member.repository.RefreshTokenRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +17,15 @@ public class RefreshTokenService {
     public void createRefreshToken(Long memberId, String token, Long expiry) {
         RefreshToken refreshToken = RefreshToken.from(memberId, token, expiry, RefreshTokenStatus.ACTIVATE);
         refreshTokenRepository.save(refreshToken);
+    }
+
+    public RefreshToken getRefreshToken(Long memberId, String token) {
+        return refreshTokenRepository.findBy(memberId, token)
+                .orElseThrow(() -> new CustomException(MemberStatus.REFRESH_TOKEN_UNAUTHORIZED));
+    }
+
+    public void upsertRefreshToken(Long memberId, String token, Long expiry) {
+        RefreshToken refreshToken = RefreshToken.from(memberId, token, expiry, RefreshTokenStatus.ACTIVATE);
+        refreshTokenRepository.upsert(refreshToken);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/member/service/RefreshTokenService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/RefreshTokenService.java
@@ -1,0 +1,19 @@
+package store.sonyk9919.api.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.domain.member.entitiy.RefreshToken;
+import store.sonyk9919.api.domain.member.entitiy.RefreshTokenStatus;
+import store.sonyk9919.api.domain.member.repository.RefreshTokenRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void createRefreshToken(Long memberId, String token, Long expiry) {
+        RefreshToken refreshToken = RefreshToken.from(memberId, token, expiry, RefreshTokenStatus.ACTIVATE);
+        refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package store.sonyk9919.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
@@ -15,7 +15,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-
     @Value("${spring.data.redis.host}")
     private String host;
 
@@ -43,6 +42,12 @@ public class RedisConfig {
     @Bean
     public RedisScript<Boolean> clearMemberRefreshTokens() {
         ClassPathResource classPathResource = new ClassPathResource("redis/scripts/create_new_refresh_token_member.lua");
+        return RedisScript.of(classPathResource, Boolean.class);
+    }
+
+    @Bean
+    public RedisScript<Boolean> rotateRefreshToken() {
+        ClassPathResource classPathResource = new ClassPathResource("redis/scripts/rotate_refresh_token.lua");
         return RedisScript.of(classPathResource, Boolean.class);
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
@@ -3,9 +3,11 @@ package store.sonyk9919.api.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -36,5 +38,11 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisScript<Boolean> clearMemberRefreshTokens() {
+        ClassPathResource classPathResource = new ClassPathResource("redis/scripts/create_new_refresh_token_member.lua");
+        return RedisScript.of(classPathResource, Boolean.class);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -33,6 +33,11 @@ spring:
         use_sql_comments: true
     defer-datasource-initialization: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   rabbitmq:
     host: ${custom.dev.rabbitmq.host:localhost}
     port: 5672

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -58,6 +58,7 @@ jwt:
   secret: ${custom.security.jwt.secret:ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=}
   expiry:
     access: 3600
+    refresh: 604800
 
 security:
   cookie:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,7 +27,8 @@ analysis:
 jwt:
   secret: ${custom.jwt.secret}
   expiry:
-    access: 3600
+    access: ${custom.jwt.access:3600}
+    refresh: ${custom.jwt.refresh:604800}
 
 security:
   cookie:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,11 @@ spring:
     hibernate:
       ddl-auto: create
 
+  data:
+    redis:
+      host: ${custom.redis.host}
+      port: ${custom.redis.port}
+
   rabbitmq:
     host: ${custom.prod.rabbitmq.host}
     port: ${custom.prod.rabbitmq.port}

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -22,3 +22,7 @@ custom:
     expiry:
       access: NEED_TO_INPUT
       refresh: NEED_TO_INPUT
+
+  redis:
+    host: NEED_TO_INPUT
+    port: NEED_TO_INPUT

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -19,3 +19,6 @@ custom:
 
   jwt:
     secret: NEED_TO_INPUT
+    expiry:
+      access: NEED_TO_INPUT
+      refresh: NEED_TO_INPUT

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -27,6 +27,11 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     org.hibernate.SQL: DEBUG
@@ -42,6 +47,7 @@ jwt:
   secret: ZiF5Qkeoy20Fk/iVa3MiQyc50tz5sm7S2i6UER7QkAo=
   expiry:
     access: 3600
+    refresh: 604800
 
 security:
   cookie:

--- a/src/main/resources/redis/scripts/create_new_refresh_token_member.lua
+++ b/src/main/resources/redis/scripts/create_new_refresh_token_member.lua
@@ -1,0 +1,30 @@
+-- KEYS
+-- [1]: RT:memberId
+-- [2]: RT:INDEX:memberId
+-- [3]: RT:memberId:token
+-- ARGV
+-- [1]: token
+-- [2]: entityJson
+-- [3]: ttl
+
+local baseKey = KEYS[1]
+local indexKey = KEYS[2]
+local newTokenKey = KEYS[3]
+
+local newToken = ARGV[1]
+local entityJson = ARGV[2]
+local ttl = tonumber(ARGV[3])
+
+local tokens = redis.call('SMEMBERS', indexKey)
+
+if #tokens > 0 then
+    for _, v in ipairs(tokens) do
+        redis.call('DEL', baseKey .. ":" .. v)
+    end
+end
+
+redis.call('DEL', indexKey)
+redis.call('SET', newTokenKey, entityJson, 'EX', ttl)
+redis.call('SADD', indexKey, newToken)
+
+return true

--- a/src/main/resources/redis/scripts/rotate_refresh_token.lua
+++ b/src/main/resources/redis/scripts/rotate_refresh_token.lua
@@ -1,0 +1,41 @@
+-- KEYS
+-- [1]: RT:{memberId}
+-- [2]: RT:INDEX:{memberId}
+-- [3]: RT:{memberId}:{token}
+-- ARGV
+-- [1]: token
+-- [2]: refresh token entity
+-- [3]: token expiry (sec)
+-- [4]: stale status
+-- [5]: grace expiry (sec)
+
+local baseKey = KEYS[1]
+local indexKey = KEYS[2]
+local newTokenKey = KEYS[3]
+
+local newToken = ARGV[1]
+local entityJson = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local stale = ARGV[4]
+local graceTtl = tonumber(ARGV[5])
+
+local tokens = redis.call('SMEMBERS', indexKey)
+
+if #tokens > 0 then
+    for _, token in ipairs(tokens) do
+        local oldTokenKey = baseKey .. ':' .. token
+
+        if redis.call('EXISTS', oldTokenKey) == 1 then
+            local json = cjson.decode(redis.call('GET', oldTokenKey))
+            json.status = stale
+            redis.call('SET', oldTokenKey, cjson.encode(json), 'EX', graceTtl)
+        else
+            redis.call('SREM', indexKey, token)
+        end
+    end
+end
+
+redis.call('SET', newTokenKey, entityJson, 'EX', ttl)
+redis.call('SADD', indexKey, newToken)
+
+return true

--- a/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
+++ b/src/test/java/store/sonyk9919/api/domain/auth/AuthE2ETest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,10 +23,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 import store.sonyk9919.api.domain.auth.dto.AuthDto;
 import store.sonyk9919.api.domain.auth.filter.JwtAuthenticationFilter;
 import store.sonyk9919.api.domain.member.entitiy.AccountRole;
 import tools.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -73,6 +80,13 @@ public class AuthE2ETest {
 
         mockMvc.perform(get("/auth/test/admin").cookie(cookies))
                 .andExpect(status().isForbidden());
+
+        Cookie[] withoutAccessToken = Arrays.stream(cookies)
+                .filter(cookie -> !cookie.getName().equals("accessToken"))
+                .toArray(Cookie[]::new);
+
+        mockMvc.perform(get("/auth/test/user").cookie(withoutAccessToken))
+                .andExpect(status().isOk()).andReturn();
     }
 
     @TestConfiguration
@@ -97,6 +111,26 @@ public class AuthE2ETest {
                     .httpBasic(AbstractHttpConfigurer::disable)
                     .addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
             return httpSecurity.build();
+        }
+    }
+
+    @Testcontainers
+    @TestConfiguration
+    public static class RedisTestConfig {
+
+        private static final int REDIS_PORT = 6379;
+
+        @Container
+        private static GenericContainer<?> redis = new GenericContainer<>("redis:8-alpine")
+                .withExposedPorts(REDIS_PORT);
+
+        static {
+            redis.start();
+        }
+
+        @Bean
+        public RedisConnectionFactory redisConnectionFactory() {
+            return new LettuceConnectionFactory(redis.getHost(), redis.getMappedPort(REDIS_PORT));
         }
     }
 }


### PR DESCRIPTION
## 주요 변경사항

### Feature

- refreshToken을 통해 accessToken을 재발급 받을 수 있도록 하였습니다.

### Chore

- Redis 테스트를 위한 TestContainer 의존성을 추가하였습니다.

### Test

- 인증/인가 E2E테스트에 refreshToken에 대한 테스트 코드를 추가하였습니다.

## 상세 설명

- [Redis Lua Script](https://redis.io/docs/latest/develop/programmability/eval-intro/)를 사용해 refreshToken의 등록/변경 등의 일련의 과정을 한번에, 원자적으로 수행하도록 했습니다.
- 테스트 시 독립적인 환경을 위해 TestContainer 모듈을 통해 테스트 용 Redis 컨테이너를 사용하도록 하였습니다.
  -  따라서 호스트 PC에 Docker가 설치되어 있지 않다면 테스트를 할 수 없습니다.

## 체크리스트

- [x] 통합테스트 시 TestConatiner 동작 테스트


## Jira 링크

- https://untitled.atlassian.net/browse/KAN-165

## 참고사항

