### PR TITLE
feat: ResponseAdvice 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/analysis/controller/AnalysisController.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/controller/AnalysisController.java
@@ -9,11 +9,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.ErrorResponse;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import store.sonyk9919.api.domain.analysis.dto.AnalysisResultDto;
+import store.sonyk9919.api.domain.analysis.dto.RequestIdDto;
 import store.sonyk9919.api.domain.analysis.service.AnalysisFacade;
 import store.sonyk9919.api.domain.analysis.service.AnalysisResultFinder;
 import store.sonyk9919.api.domain.analysis.service.AnalysisSseFacade;
@@ -35,8 +41,8 @@ public class AnalysisController {
                     "응답으로 즉시 requestId를 반환하고 실제 분석 결과는 SSE를 통해 수신해야 합니다."
     )
     @PostMapping(value = "/request", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BaseResponse<String>> requestAnalysis(@RequestParam("image") MultipartFile image) {
-        return BaseResponse.success(analysisFacade.submitAnalysis(image));
+    public RequestIdDto requestAnalysis(@RequestParam("image") MultipartFile image) {
+        return RequestIdDto.from(analysisFacade.submitAnalysis(image));
     }
 
     @Operation(

--- a/src/main/java/store/sonyk9919/api/domain/analysis/dto/RequestIdDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/dto/RequestIdDto.java
@@ -1,5 +1,6 @@
 package store.sonyk9919.api.domain.analysis.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestIdDto {
+
+    @JsonProperty("request_id")
     private final String requestId;
 
     public static RequestIdDto from(String requestId){

--- a/src/main/java/store/sonyk9919/api/domain/analysis/dto/RequestIdDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/dto/RequestIdDto.java
@@ -1,0 +1,15 @@
+package store.sonyk9919.api.domain.analysis.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestIdDto {
+    private final String requestId;
+
+    public static RequestIdDto from(String requestId){
+        return new RequestIdDto(requestId);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/sse/service/SseEmitterService.java
+++ b/src/main/java/store/sonyk9919/api/domain/sse/service/SseEmitterService.java
@@ -27,7 +27,7 @@ public class SseEmitterService {
         sendEvent(
                 requestId,
                 SseEventType.CONNECT,
-                BaseResponse.success().getBody()
+                BaseResponse.success()
         );
 
         return emitter;

--- a/src/main/java/store/sonyk9919/api/domain/sse/service/SseResultSender.java
+++ b/src/main/java/store/sonyk9919/api/domain/sse/service/SseResultSender.java
@@ -16,7 +16,7 @@ public class SseResultSender {
         sseEmitterService.sendAndComplete(
                 requestId,
                 SseEventType.ANALYSIS_RESULT,
-                BaseResponse.success(data).getBody()
+                BaseResponse.success(data)
         );
     }
 

--- a/src/main/java/store/sonyk9919/api/global/common/advice/GlobalResponseAdvice.java
+++ b/src/main/java/store/sonyk9919/api/global/common/advice/GlobalResponseAdvice.java
@@ -1,0 +1,38 @@
+package store.sonyk9919.api.global.common.advice;
+
+import lombok.NonNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import store.sonyk9919.api.global.common.dto.BaseResponse;
+
+@RestControllerAdvice
+public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(@NonNull MethodParameter returnType,
+                            @NonNull Class<? extends HttpMessageConverter<?>> converterType
+    ) {
+        return true;
+    }
+
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  @NonNull MethodParameter returnType,
+                                  @NonNull MediaType selectedContentType,
+                                  @NonNull Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  @NonNull ServerHttpRequest request,
+                                  @NonNull ServerHttpResponse response
+    ) {
+        if (body instanceof BaseResponse<?>) {
+            return body;
+        }
+
+        return BaseResponse.success(body);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/BaseResponse.java
@@ -13,39 +13,33 @@ public class BaseResponse<T> {
 
     private BaseResponse(BaseResponseStatus status, String message, T data) {
         this.code = status.getCode();
-        this.message = message;
+        this.message = (message != null) ? message : status.getMessage();
         this.data = data;
     }
 
-    public static ResponseEntity<BaseResponse<Void>> success() {
-        return build(SuccessStatus.SUCCESS, null, null);
+    public static BaseResponse<Void> success (){
+        return new BaseResponse<>(SuccessStatus.SUCCESS, null, null);
     }
 
-    public static <T> ResponseEntity<BaseResponse<T>> success(T data) {
-        return build(SuccessStatus.SUCCESS, null, data);
-    }
-
-    public static <T> ResponseEntity<BaseResponse<T>> success(BaseResponseStatus status, T data) {
-        return build(status, null, data);
+    public static <T> BaseResponse<T> success(T data) {
+        return new BaseResponse<>(SuccessStatus.SUCCESS, null, data);
     }
 
     public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status) {
-        return build(status, null, null);
+        return buildError(status, null, null);
     }
 
     public static ResponseEntity<BaseResponse<Void>> error(BaseResponseStatus status, String customMessage) {
-        return build(status, customMessage, null);
+        return buildError(status, customMessage, null);
     }
 
     public static <T> ResponseEntity<BaseResponse<T>> error(BaseResponseStatus status, T data) {
-        return build(status, null, data);
+        return buildError(status, null, data);
     }
 
-    private static <T> ResponseEntity<BaseResponse<T>> build(BaseResponseStatus status, String customMessage, T data) {
-        String message = (customMessage != null) ? customMessage : status.getMessage();
-
+    private static <T> ResponseEntity<BaseResponse<T>> buildError(BaseResponseStatus status, String customMessage, T data) {
         return ResponseEntity
                 .status(status.getHttpStatus())
-                .body(new BaseResponse<>(status, message, data));
+                .body(new BaseResponse<>(status, customMessage, data));
     }
 }

--- a/src/test/java/store/sonyk9919/api/global/common/advice/GlobalResponseAdviceTest.java
+++ b/src/test/java/store/sonyk9919/api/global/common/advice/GlobalResponseAdviceTest.java
@@ -1,0 +1,43 @@
+package store.sonyk9919.api.global.common.advice;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class GlobalResponseAdviceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("DTO 반환 시 BaseResponse 형식으로 래핑된다")
+    void wrappedDto() throws Exception {
+        mockMvc.perform(get("/advice/dto"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON_200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.data.data").value("hello"));
+    }
+
+    @Test
+    @DisplayName("이미 BaseResponse로 래핑된 경우 이중 래핑되지 않는다")
+    void notDupWrapped() throws Exception {
+        mockMvc.perform(get("/advice/baseResponse"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON_200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.data.data").value("hello"))
+                .andExpect(jsonPath("$.data.code").doesNotExist());
+    }
+}

--- a/src/test/java/store/sonyk9919/api/global/common/advice/controller/GlobalResponseAdviceController.java
+++ b/src/test/java/store/sonyk9919/api/global/common/advice/controller/GlobalResponseAdviceController.java
@@ -1,0 +1,29 @@
+package store.sonyk9919.api.global.common.advice.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import store.sonyk9919.api.global.common.dto.BaseResponse;
+
+@RestController
+@RequestMapping("/advice")
+public class GlobalResponseAdviceController {
+
+    @Getter
+    @AllArgsConstructor
+    static class TestDto {
+        private String data;
+    }
+
+    @GetMapping("/dto")
+    public TestDto dto(){
+        return new TestDto("hello");
+    }
+
+    @GetMapping("/baseResponse")
+    public BaseResponse<TestDto> baseResponse(){
+        return BaseResponse.success(new TestDto("hello"));
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 기존 엔드포인트 반환 타입 dto로 변경하고 ResponseBodyAdvice로 BaseResponse으로 자동 반환되도록 수정

### Feature
- ResponseBodyAdvice을 구현해 GlobalResponseAdvice 추가

### Test
- dto로 반환 시 BaseResponse 형식으로 반환되는지 확인
- 이미 BaseResponse 형식으로 감싸진 경우 이중으로 감싸지 않는지 확인

## 상세 설명

## 체크리스트
- [x] responseAdvice 구현
- [x] 기존 컨트롤러 수동 매핑 제거

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-203

## 참고사항
