### PR TITLE
refactor: DetectedItemDto 수정으로 인한 코드 리펙토링

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/analysis/dto/AnalysisResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/dto/AnalysisResponseDto.java
@@ -3,13 +3,13 @@ package store.sonyk9919.api.domain.analysis.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AnalysisResponseDto {
 
     @JsonProperty("request_id")
@@ -19,4 +19,8 @@ public class AnalysisResponseDto {
 
     @JsonProperty("detected_items")
     private List<DetectedItemDto> detectedItems;
+
+    public static AnalysisResponseDto of(String requestId, List<DetectedItemDto> detectedItems) {
+        return new AnalysisResponseDto(requestId, detectedItems.size(), detectedItems);
+    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/analysis/dto/DetectedItemDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/analysis/dto/DetectedItemDto.java
@@ -5,31 +5,24 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
-import store.sonyk9919.api.domain.taxonomy.entity.TrashTaxonomy;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DetectedItemDto {
     private String category;
-    private String subcategory;
-    private Confidence confidence;
+    private Double confidence;
     private String filename;
 
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @ToString
-    public static class Confidence {
-        private Double object;
-        private Double material;
+    private DetectedItemDto(String category){
+        this.category = category;
+    }
+    public static DetectedItemDto from(String category) {
+        return new DetectedItemDto(category);
     }
 
-    public static DetectedItemDto of(String category, String subcategory) {
-        DetectedItemDto item = new DetectedItemDto();
-        item.category = category;
-        item.subcategory = subcategory;
-        return item;
+    public static DetectedItemDto of(String category, Double confidence, String filename) {
+        return new DetectedItemDto(category, confidence, filename);
     }
 
     @Override
@@ -37,16 +30,11 @@ public class DetectedItemDto {
         if (this == o) return true;
         if (!(o instanceof DetectedItemDto)) return false;
         DetectedItemDto other = (DetectedItemDto) o;
-        return Objects.equals(category, other.category)
-                && Objects.equals(subcategory, other.subcategory);
+        return Objects.equals(category, other.category);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(category, subcategory);
-    }
-
-    public String getKey() {
-        return TrashTaxonomy.generateKey(category, subcategory);
+        return Objects.hash(category);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/taxonomy/entity/TrashTaxonomy.java
+++ b/src/main/java/store/sonyk9919/api/domain/taxonomy/entity/TrashTaxonomy.java
@@ -28,10 +28,4 @@ public class TrashTaxonomy {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subcategory_id", nullable = false)
     private TrashSubCategory subCategory;
-
-    public static final String KEY_DELIMITER = ":";
-
-    public static String generateKey(String category, String subcategory) {
-        return category + KEY_DELIMITER + subcategory;
-    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/taxonomy/repository/TrashTaxonomyRepositoryImpl.java
+++ b/src/main/java/store/sonyk9919/api/domain/taxonomy/repository/TrashTaxonomyRepositoryImpl.java
@@ -3,7 +3,6 @@ package store.sonyk9919.api.domain.taxonomy.repository;
 import static com.querydsl.core.group.GroupBy.groupBy;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Collections;
 import java.util.List;
@@ -34,23 +33,18 @@ public class TrashTaxonomyRepositoryImpl implements TrashTaxonomyRepositoryCusto
             return Collections.emptyMap();
         }
 
-        StringExpression key = category.ko
-                .concat(TrashTaxonomy.KEY_DELIMITER)
-                .concat(subCategory.ko);
-
         return queryFactory
                 .selectFrom(taxonomy)
                 .join(taxonomy.category, category).fetchJoin()
                 .join(taxonomy.subCategory, subCategory).fetchJoin()
                 .where(condition)
-                .transform(groupBy(key).as(taxonomy));
+                .transform(groupBy(subCategory.ko).as(taxonomy));
     }
 
     private BooleanExpression buildOrCondition(List<DetectedItemDto> detectedItems) {
         return detectedItems.stream()
                 .distinct()
-                .map(item -> category.ko.eq(item.getCategory())
-                        .and(subCategory.ko.eq(item.getSubcategory())))
+                .map(item -> subCategory.ko.eq(item.getCategory()))
                 .reduce(BooleanExpression::or)
                 .orElse(null);
     }

--- a/src/main/java/store/sonyk9919/api/domain/trash/service/TrashMapper.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/service/TrashMapper.java
@@ -17,7 +17,7 @@ public class TrashMapper {
     public List<Trash> toTrashes(AnalysisRequest analysisRequest, List<DetectedItemDto> detectedItems, Map<String, TrashTaxonomy> taxonomyMap) {
         return detectedItems.stream()
                 .filter(item -> hasTaxonomy(item, taxonomyMap))
-                .map(item -> Trash.create(analysisRequest, taxonomyMap.get(item.getKey()), item.getFilename()))
+                .map(item -> Trash.create(analysisRequest, taxonomyMap.get(item.getCategory()), item.getFilename()))
                 .collect(Collectors.toList());
     }
 
@@ -28,11 +28,9 @@ public class TrashMapper {
     }
 
     private boolean hasTaxonomy(DetectedItemDto detectedItem, Map<String, TrashTaxonomy> taxonomyMap) {
-        boolean exists = taxonomyMap.containsKey(detectedItem.getKey());
+        boolean exists = taxonomyMap.containsKey(detectedItem.getCategory());
         if (!exists) {
-            log.warn("[Taxonomy] fail to mapping - category: {}, subcategory: {}",
-                    detectedItem.getCategory(),
-                    detectedItem.getSubcategory());
+            log.warn("[Taxonomy] fail to mapping - category: {}", detectedItem.getCategory());
         }
         return exists;
     }

--- a/src/test/java/store/sonyk9919/api/domain/taxonomy/repository/TrashTaxonomyRepositoryTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/taxonomy/repository/TrashTaxonomyRepositoryTest.java
@@ -39,54 +39,52 @@ class TrashTaxonomyRepositoryTest {
         assertThat(allTaxonomyList.size()).isEqualTo(allTexonomySet.size());
     }
 
-    @ParameterizedTest(name = "categoryName = {0}, subCategoryName = {1}")
+    @ParameterizedTest(name = "subCategoryName = {0}, categoryName = {1}")
     @CsvSource({
-            "전용함, 일회용컵(페트병류)", "전용함, 일반페트병(페트병류)", "플라스틱류, 대용량통(플라스틱)",
-            "플라스틱류, 밀폐용기(플라스틱)", "비닐류, 식품봉지(비닐)", "비닐류, '리필용기(비닐)'"
+            "일회용컵(페트병류), 전용함",
+            "일반페트병(페트병류), 전용함",
+            "대용량통(플라스틱), 플라스틱류",
+            "밀폐용기(플라스틱), 플라스틱류",
+            "식품봉지(비닐), 비닐류",
+            "리필용기(비닐), 비닐류"
     })
-    @DisplayName("카테고리 이름과 서브 카테고리의 이름으로 최종 분류를 찾을 수 있음")
-    void findTaxonomy(String categoryName, String subCategoryName) {
+    @DisplayName("소분류 이름으로 taxonomy를 찾을 수 있고 대분류도 올바르게 매핑됨")
+    void findTaxonomy(String subCategoryName, String categoryName) {
         Map<String, TrashTaxonomy> allTaxonomy = trashTaxonomyRepository
-                .findAllTaxonomy(List.of(DetectedItemDto.of(categoryName, subCategoryName)));
+                .findAllTaxonomy(List.of(DetectedItemDto.from(subCategoryName)));
 
         assertThat(allTaxonomy.size()).isNotZero();
-        TrashTaxonomy taxonomy = allTaxonomy.get(TrashTaxonomy.generateKey(categoryName, subCategoryName));
+        TrashTaxonomy taxonomy = allTaxonomy.get(subCategoryName);
 
         assertThat(taxonomy).isNotNull();
-        assertThat(taxonomy.getCategory().getName()).isEqualTo(categoryName);
         assertThat(taxonomy.getSubCategory().getName()).isEqualTo(subCategoryName);
+        assertThat(taxonomy.getCategory().getName()).isEqualTo(categoryName);
     }
 
-    @ParameterizedTest(name = "categoryName = {0}, subCategoryName = {1}")
+    @ParameterizedTest(name = "subCategoryName = {0}")
     @CsvSource({
-            "플라스틱, Bottle", "용기류, Container", "금속캔, Cosmetics",
-            "비닐류, Bottle", "유리병류, Balloon", "비닐류, Beer"
+            "플라스틱(Bottle)", "용기류(Container)", "금속캔(Cosmetics)",
+            "비닐류(Bottle)", "유리병류(Balloon)", "비닐류(Beer)"
     })
     @DisplayName("없는 조합으로 검색 시 Null 값이 반환")
-    void notFoundTaxonomy(String categoryName, String subCategoryName) {
+    void notFoundTaxonomy(String subcategory) {
         Map<String, TrashTaxonomy> allTaxonomy = trashTaxonomyRepository
-                .findAllTaxonomy(List.of(DetectedItemDto.of(categoryName, subCategoryName)));
+                .findAllTaxonomy(List.of(DetectedItemDto.from(subcategory)));
 
         assertThat(allTaxonomy.size()).isZero();
     }
 
     @Test
-    @DisplayName("category의 name과 subcategory의 alias의 조합한 키들(list)로 일치하는 taxonomy 다중 조회")
-    void findTaxonomiesByCombinedKeys() {
+    @DisplayName("여러 소분류를 한 번에 다중 조회")
+    void findAllTaxonomyByMultipleKeys() {
         List<DetectedItemDto> detectedItems = List.of(
-                DetectedItemDto.of("전용함", "일회용컵(페트병류)"),
-                DetectedItemDto.of("전용함", "일반페트병(페트병류)")
+                DetectedItemDto.from("일회용컵(페트병류)"),
+                DetectedItemDto.from("소주병(유리병)")
         );
 
         Map<String, TrashTaxonomy> result = trashTaxonomyRepository.findAllTaxonomy(detectedItems);
 
         assertThat(result).hasSize(2);
-        assertThat(result.keySet()).containsExactlyInAnyOrder(
-                TrashTaxonomy.generateKey("전용함", "일회용컵(페트병류)"),
-                TrashTaxonomy.generateKey("전용함", "일반페트병(페트병류)")
-        );
-        assertThat(result.values())
-                .extracting(t -> t.getSubCategory().getName())
-                .containsExactlyInAnyOrder("일회용컵(페트병류)", "일반페트병(페트병류)");
+        assertThat(result.keySet()).containsExactlyInAnyOrder("일회용컵(페트병류)", "소주병(유리병)");
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 기존 프로토타입에 맞춰져 있던 DTO를 수정했습니다.


### Refactor
- DetectedItenDto
  - confidence 필드 Double로 수정
  - subcategory 필드 제거
- 변경에 따른 서비스 부분 수정

## 상세 설명

- 이전 대분류:소분류 조합 키로 조회 방식에서 소분류의 한글 명칭로 taxonomy를 찾아 category와 subcategory 모두 조회 방식으로 리펙토링 했습니다.

## 체크리스트
- [x] detectedItenDto 수정



