### PR TITLE
fix: 이미지 경로가 잘 못 생성되는 문제

### DIFF
--- a/src/main/java/store/sonyk9919/api/global/file/resolver/FilePathResolver.java
+++ b/src/main/java/store/sonyk9919/api/global/file/resolver/FilePathResolver.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
 import store.sonyk9919.api.global.file.constants.FileDirectory;
 
 import java.nio.file.Paths;
@@ -27,7 +28,8 @@ public class FilePathResolver {
     }
 
     public String resolveOutput(String name) {
-        return Paths.get(EXTERNAL_PATH, name)
-                .toString();
+        return UriComponentsBuilder.fromUriString(EXTERNAL_PATH)
+                .path(name)
+                .toUriString();
     }
 }


### PR DESCRIPTION
## 주요 변경사항

### Fix

- 이미지 전체 경로 생성 시 prefix가 일부 생략되는 문제를 해결하였습니다.

## 상세 설명

AS-IS
- https:/file.sonyk9919.store:20024/1234.jpg ( "/" 1개 누락)
TO-BE
- https://file.sonyk9919.store:20024/1234.jpg 

## 체크리스트

- [x] 스웨거 테스트

## 참고사항

- 크게 보실건 없을 것 같아서 리뷰없이 반영하겠습니다.