### PR TITLE
feat: 분석 객체 선택 확정 API 구현

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/trash/controller/TrashConfirmController.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/controller/TrashConfirmController.java
@@ -1,0 +1,29 @@
+package store.sonyk9919.api.domain.trash.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import store.sonyk9919.api.domain.trash.dto.ConfirmRequestDto;
+import store.sonyk9919.api.domain.trash.dto.ConfirmResponseDto;
+import store.sonyk9919.api.domain.trash.service.TrashConfirmService;
+
+@RestController
+@RequestMapping("/api/v1/trashes")
+@RequiredArgsConstructor
+public class TrashConfirmController {
+
+    private final TrashConfirmService trashConfirmService;
+
+    @Operation(
+            summary = "분석 객체 선택 확정",
+            description = "클라이언트가 선택한 trash_uuid들을 받아 분석 결과(serial)로 묶어 저장합니다. " +
+                    "반환된 serial로 페이징 조회가 가능합니다."
+    )
+    @PostMapping("/confirm")
+    public ConfirmResponseDto confirmTrash(@RequestBody ConfirmRequestDto request) {
+        return trashConfirmService.confirm(request.getTrashUuids());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmRequestDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmRequestDto.java
@@ -1,0 +1,18 @@
+package store.sonyk9919.api.domain.trash.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfirmRequestDto {
+
+    @JsonProperty("trash_uuids")
+    private List<String> trashUuids;
+
+    public List<String> getTrashUuids() {
+        if(trashUuids == null) return List.of();
+        return List.copyOf(trashUuids);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmRequestDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmRequestDto.java
@@ -1,6 +1,5 @@
 package store.sonyk9919.api.domain.trash.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ConfirmRequestDto {
 
-    @JsonProperty("trash_uuids")
     private List<String> trashUuids;
 
     public List<String> getTrashUuids() {

--- a/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/dto/ConfirmResponseDto.java
@@ -1,0 +1,15 @@
+package store.sonyk9919.api.domain.trash.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfirmResponseDto {
+    private final String serial;
+
+    public static ConfirmResponseDto from(String serial) {
+        return new ConfirmResponseDto(serial);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
@@ -57,4 +57,8 @@ public class Trash {
     public void confirmResult(AnalysisResult analysisResult) {
         this.analysisResult = analysisResult;
     }
+
+    public boolean isConfirmed(){
+        return analysisResult != null;
+    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/TrashStatus.java
@@ -8,9 +8,10 @@ import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 @Getter
 @RequiredArgsConstructor
 public enum TrashStatus implements BaseResponseStatus {
-    NOT_FOUND_TRASH("TRASH-001", HttpStatus.NOT_FOUND, "존재하지 않는 쓰레기 입니다.");
+    NOT_FOUND_TRASH(HttpStatus.NOT_FOUND, "TRASH-001", "존재하지 않는 쓰레기 입니다."),
+    ALREADY_CONFIRMED_TRASH(HttpStatus.CONFLICT, "TRASH-002", "이미 확정 처리된 쓰레기입니다.");
 
-    private final String code;
     private final HttpStatus httpStatus;
+    private final String code;
     private final String message;
 }

--- a/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
@@ -9,4 +9,6 @@ public interface TrashRepository extends JpaRepository<Trash, Long> {
 
     @EntityGraph(attributePaths = {"taxonomy", "taxonomy.category", "taxonomy.subCategory"})
     List<Trash> findByAnalysisRequest_RequestId(String requestId);
+
+    List<Trash> findAllByTrashUuidIn(List<String> trashUuids);
 }

--- a/src/main/java/store/sonyk9919/api/domain/trash/service/TrashConfirmService.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/service/TrashConfirmService.java
@@ -1,0 +1,49 @@
+package store.sonyk9919.api.domain.trash.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisResult;
+import store.sonyk9919.api.domain.analysis.repository.AnalysisResultRepository;
+import store.sonyk9919.api.domain.trash.dto.ConfirmResponseDto;
+import store.sonyk9919.api.domain.trash.entity.Trash;
+import store.sonyk9919.api.domain.trash.entity.TrashStatus;
+import store.sonyk9919.api.domain.trash.repository.TrashRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class TrashConfirmService {
+    private final TrashRepository trashRepository;
+    private final AnalysisResultRepository analysisResultRepository;
+
+    @Transactional
+    public ConfirmResponseDto confirm(List<String> trashUuids) {
+        List<Trash> trashes = findAndValidTrashes(trashUuids);
+
+        AnalysisResult analysisResult = AnalysisResult.create();
+        analysisResultRepository.save(analysisResult);
+
+        trashes.forEach(trash -> trash.confirmResult(analysisResult));
+
+        return ConfirmResponseDto.from(analysisResult.getSerial());
+    }
+
+    private List<Trash> findAndValidTrashes(List<String> trashUuids) {
+        if (trashUuids.isEmpty()){
+            throw new CustomException(TrashStatus.NOT_FOUND_TRASH);
+        }
+
+        List<Trash> trashes = trashRepository.findAllByTrashUuidIn(trashUuids);
+        long uniqueCount = trashUuids.stream().distinct().count();
+
+        if (trashes.size() != uniqueCount){
+            throw new CustomException(TrashStatus.NOT_FOUND_TRASH);
+        }
+        if (trashes.stream().anyMatch(Trash::isConfirmed)) {
+            throw new CustomException(TrashStatus.ALREADY_CONFIRMED_TRASH);
+        }
+        return trashes;
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/trash/service/TrashConfirmServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/trash/service/TrashConfirmServiceTest.java
@@ -1,0 +1,79 @@
+package store.sonyk9919.api.domain.trash.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.analysis.entity.AnalysisRequest;
+import store.sonyk9919.api.domain.analysis.repository.AnalysisRequestRepository;
+import store.sonyk9919.api.domain.taxonomy.entity.TrashTaxonomy;
+import store.sonyk9919.api.domain.taxonomy.repository.TrashTaxonomyRepository;
+import store.sonyk9919.api.domain.trash.dto.ConfirmResponseDto;
+import store.sonyk9919.api.domain.trash.entity.Trash;
+import store.sonyk9919.api.domain.trash.repository.TrashRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@SpringBootTest
+@Transactional
+class TrashConfirmServiceTest {
+
+    @Autowired
+    private TrashConfirmService trashConfirmService;
+
+    @Autowired
+    private TrashRepository trashRepository;
+
+    @Autowired
+    private AnalysisRequestRepository analysisRequestRepository;
+
+    @Autowired
+    private TrashTaxonomyRepository trashTaxonomyRepository;
+
+    private Trash trash1;
+    private Trash trash2;
+
+    @BeforeEach
+    void setup() {
+        AnalysisRequest request = analysisRequestRepository.save(AnalysisRequest.createWithUUID());
+        TrashTaxonomy taxonomy = trashTaxonomyRepository.findAll().get(0);
+        trash1 = trashRepository.save(Trash.create(request, taxonomy, "a.jpg"));
+        trash2 = trashRepository.save(Trash.create(request, taxonomy, "b.jpg"));
+    }
+
+    @Test
+    @DisplayName("선택한 trash_uuid 목록을 선택하면 serial이 반환되고 Trash에 AnalysisResult 삽입")
+    void confirmSuccess() {
+        List<String> trashUuids = List.of(trash1.getTrashUuid(), trash2.getTrashUuid());
+
+        ConfirmResponseDto response = trashConfirmService.confirm(trashUuids);
+        List<Trash> confirmed = trashRepository.findAllByTrashUuidIn(trashUuids);
+
+        confirmed.forEach(t ->
+                assertThat(t.getAnalysisResult().getSerial()).isEqualTo(response.getSerial())
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 trash_uuid 포함하면 confirm 실패")
+    void confirmNotFound() {
+        assertThatThrownBy(() ->
+                trashConfirmService.confirm(List.of(trash1.getTrashUuid(), "fake1234"))
+        ).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("이미 confirm된 Trash를 다시 시도하면 confirm 실패")
+    void alreadyConfirmed() {
+        trashConfirmService.confirm(List.of(trash1.getTrashUuid()));
+
+        assertThatThrownBy(() ->
+                trashConfirmService.confirm(List.of(trash1.getTrashUuid()))
+        ).isInstanceOf(CustomException.class);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 쓰레기 분석 객체 선택 확정 API 구현

### Feature
- 클라이언트가 선택한 `trash_uuid` 목록을 받아 `AnalysisResult`로 묶어 저장
- 확정 완료 후 페이징 조회에 사용할 `serial` 반환

### Test
- 잘못된 trash_uuid에 대한 테스트

## 상세 설명
```
[1] POST /request → request_id 반환
[2] GET /subscribe/{request_id} → 감지된 전체 객체 SSE 수신
[3] 클라이언트가 원하는 객체 선택 → POST로 서버에 요청
   [3-1] [4]로 라우팅할 수 있도록 serial을 반환
[4] GET /result/{serial} → 저장된 객체 목록 페이징 조회 
```

- 3번에 대한 엔드포인트 작성으로 클라이언트가 선택한 trash_uuid 목록을 확정하여 AnalysisResult(serial)로 묶어 저장하는 API를 구현 했씁니다.
- 반환된 serial로 이후 페이징 조회(GET /result/{serial})를 할 수 있습니다.


## 체크리스트
- [x] 전체 흐름 실행 확인

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-276

## 참고사항
- https://docs.google.com/spreadsheets/d/1--AT0fku0dDfX5kJLJ8N6p_UBNov0GHchV8_9Q1JJB4/edit?gid=0#gid=0

- 전에 말하기로 우선 분석된 걸 남기자고 했던걸로 기억해서 미선택된 `Trash`도 유지하고 있습니다.