### PR TITLE
refactor: TrashItemDto filename 완성된 이미지 URL로 반환

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/trash/dto/TrashItemDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/dto/TrashItemDto.java
@@ -4,30 +4,25 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import store.sonyk9919.api.domain.taxonomy.entity.TrashCategory;
-import store.sonyk9919.api.domain.taxonomy.entity.TrashSubCategory;
-import store.sonyk9919.api.domain.taxonomy.entity.TrashTaxonomy;
 import store.sonyk9919.api.domain.trash.entity.Trash;
+import store.sonyk9919.api.global.file.serializer.ImageSerializer;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TrashItemDto {
     private String trashUuid;
-    private String filename;
+    @JsonSerialize(using = ImageSerializer.class) private String filename;
     private String category;
     private String subcategory;
 
     public static TrashItemDto from(Trash trash) {
-        TrashTaxonomy taxonomy = trash.getTaxonomy();
-        TrashCategory category = taxonomy.getCategory();
-        TrashSubCategory subCategory = taxonomy.getSubCategory();
-
         return new TrashItemDto(
                 trash.getTrashUuid(),
-                trash.getFilename(),
-                category.getName(),
-                subCategory.getName()
+                trash.getCropImagePath(),
+                trash.getCategoryName(),
+                trash.getSubCategoryName()
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.nio.file.Paths;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -63,7 +64,7 @@ public class Trash {
     }
 
     public String getCropImagePath() {
-        return analysisRequest.getRequestId() + "/" + filename;
+        return Paths.get(analysisRequest.getRequestId(), filename).toString();
     }
 
     public void confirmResult(AnalysisResult analysisResult) {

--- a/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/entity/Trash.java
@@ -54,6 +54,18 @@ public class Trash {
         return new Trash(analysisRequest, taxonomy, filename);
     }
 
+    public String getCategoryName() {
+        return taxonomy.getCategory().getName();
+    }
+
+    public String getSubCategoryName() {
+        return taxonomy.getSubCategory().getName();
+    }
+
+    public String getCropImagePath() {
+        return analysisRequest.getRequestId() + "/" + filename;
+    }
+
     public void confirmResult(AnalysisResult analysisResult) {
         this.analysisResult = analysisResult;
     }

--- a/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/trash/repository/TrashRepository.java
@@ -7,6 +7,6 @@ import store.sonyk9919.api.domain.trash.entity.Trash;
 
 public interface TrashRepository extends JpaRepository<Trash, Long> {
 
-    @EntityGraph(attributePaths = {"taxonomy", "taxonomy.category", "taxonomy.subCategory"})
+    @EntityGraph(attributePaths = {"taxonomy", "taxonomy.category", "taxonomy.subCategory", "analysisRequest"})
     List<Trash> findByAnalysisRequest_RequestId(String requestId);
 }

--- a/src/main/java/store/sonyk9919/api/global/file/service/FileStorage.java
+++ b/src/main/java/store/sonyk9919/api/global/file/service/FileStorage.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import store.sonyk9919.api.global.common.dto.ErrorStatus;
 import store.sonyk9919.api.global.common.exception.CustomException;
-import store.sonyk9919.api.global.file.resolver.ImageExtensionResolver;
 import store.sonyk9919.api.global.file.resolver.FilePathResolver;
 
 @Slf4j
@@ -16,7 +15,6 @@ import store.sonyk9919.api.global.file.resolver.FilePathResolver;
 @RequiredArgsConstructor
 public class FileStorage {
 
-    private final ImageExtensionResolver extensionResolver;
     private final FilePathResolver filePathResolver;
 
     public void saveFile(MultipartFile image, String fileName) {


### PR DESCRIPTION
## 주요 변경사항

- TrashItemDto의 펙토리 메서드 from 수정
- Trash 엔티티에 getter 추가 (getCropImagePath)

## 상세 설명

- 클라이언트가 requestId를 별도로 트래킹하지 않아도 되도록 분석 결과 응답의 filename을 크롭 이미지 전체 URL로 변환하게 수정

## 체크리스트

- [x] ../:requestId/:filename 으로 반환되는지 확인

## Jira 링크
- 이슈: https://github.com/untitled-KGU/server/issues/31

## 참고사항

`http://localhost:8080/api/v1/analysis/result/{serial}`  같이 전체 url이 반환됩니다.

```json
{
    "code": "COMMON_200",
    "message": "성공입니다.",
    "data": {
        "emptyItems": false,
        "request_id": "a50f28e3-d0ec-42e5-b055-737e1bba3b7c",
        "trash_items": [
            {
                "category": "플라스틱류",
                "filename": "./external/a50f28e3-d0ec-42e5-b055-737e1bba3b7c/69087318.jpg",
                "subcategory": "장난감(플라스틱)",
                "trashUuid": "42ed856e-6682-4fa4-98ce-76b51e0f98e1"
            },
            {
                "category": "플라스틱류",
                "filename": "./external/a50f28e3-d0ec-42e5-b055-737e1bba3b7c/92a70df7.jpg",
                "subcategory": "장난감(플라스틱)",
                "trashUuid": "feb067dd-6172-49c3-8edf-019d0670b3a3"
            },
            {
                "category": "플라스틱류",
                "filename": "./external/a50f28e3-d0ec-42e5-b055-737e1bba3b7c/55584feb.jpg",
                "subcategory": "장난감(플라스틱)",
                "trashUuid": "359827be-37fb-45b8-8258-1d5c47757844"
            }
        ]
    }
} 
```