### PR TITLE
fix: 결과 조회에서 item의 수를 반환하도록 수정

### DIFF
--- a/src/main/java/store/sonyk9919/api/global/dto/PageResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/global/dto/PageResponseDto.java
@@ -14,12 +14,14 @@ public class PageResponseDto<R> {
 
     private final long totalPage;
     private final int currentPage;
+    private final long totalItems;
     private final List<R> content;
 
     public static <T, R> PageResponseDto<R> from(Page<T> page, Function<T, R> transformer) {
         return new PageResponseDto<>(
                 page.getTotalPages(),
                 page.getNumber() + 1,
+                page.getTotalElements(),
                 page.getContent()
                         .stream()
                         .map(transformer)


### PR DESCRIPTION
## 주요 변경사항

- PageResponseDto에 totalItems 추가

## 상세 설명

- 결과 조회에서 반환되는 item의 수를 page.getTotalElements()로 반환하게 추가 했습니다.


## 참고사항

```json
{
    "code": "COMMON_200",
    "message": "성공입니다.",
    "data": {
        "content": [
            {
                "category": "플라스틱류",
                "image": "./external/6f784613-c617-4df5-9bb7-ece8a26a5284%5C4bda49e9.jpg",
                "subcategory": "장난감(플라스틱)",
                "uuid": "4de8c7fd-ffe6-4ab0-855a-ee1271e19e02"
            },
            {
                "category": "플라스틱류",
                "image": "./external/6f784613-c617-4df5-9bb7-ece8a26a5284%5C0ebf9ab8.jpg",
                "subcategory": "장난감(플라스틱)",
                "uuid": "2c02452e-637a-4ff7-bfd1-b3554928dd97"
            }
        ],
        "currentPage": 1,
        "totalItems": 2,
        "totalPage": 1
    }
}
```