### PR TITLE
fix: 생성되는 파일의 소유자가 root로 설정되는 문제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
   trash-app:
     build: .
     container_name: trash-app
+    user: "${APP_UID}:${APP_GID}"
     ports:
       - "${APP_PORT}:8080"
     depends_on:


### PR DESCRIPTION
## 주요 변경사항

### Fix

- 이미지 파일의 소유권이 root로 설정되는 문제를 해결하였습니다.

## 상세 설명

- 도커 컨테이너의 사용자를 별도로 지정하지 않는 경우 UID 0 (= root)로 실행되기 때문에 Volume으로 원본 파일 시스템에 생성되는 파일도 UID 0인 root로 생성되게 됩니다.
- 따라서 홈 디렉토리의 소유자인 UID 1005 (github)로 사용자를 지정합니다.

## 참고사항

X
