### PR TITLE
feat: 사용자 상세 정보 조회 및 시큐리티 필터 활성화

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/member/controller/MemberProfileController.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/controller/MemberProfileController.java
@@ -5,14 +5,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
 import store.sonyk9919.api.domain.member.dto.MemberProfileRequestDto;
+import store.sonyk9919.api.domain.member.dto.MemberProfileResponseDto;
 import store.sonyk9919.api.domain.member.service.MemberRegisterFacade;
 
 @RestController
@@ -36,5 +35,20 @@ public class MemberProfileController {
             @RequestBody MemberProfileRequestDto requestDto
     ) {
         memberRegisterFacade.registerProfile(requestDto.getNickname(), authMember.getId());
+    }
+
+    @Operation(
+            summary = "내 프로필 정보 조회",
+            description = "로그인한 사용자의 프로필 상세 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "등록된 프로필 정보를 찾을 수 없음")
+    })
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public MemberProfileResponseDto getProfile(@AuthMember AuthMemberDto authMember) {
+        return memberRegisterFacade.getProfile(authMember.getId());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/member/dto/MemberProfileResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/dto/MemberProfileResponseDto.java
@@ -1,0 +1,19 @@
+package store.sonyk9919.api.domain.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.member.entity.MemberProfile;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfileResponseDto {
+
+    private final Long id;
+    private final Long exp;
+    private final String nickname;
+
+    public static MemberProfileResponseDto from(MemberProfile profile) {
+        return new MemberProfileResponseDto(profile.getId(), profile.getExp(), profile.getNickname());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/exception/MemberStatus.java
@@ -10,6 +10,7 @@ import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 public enum MemberStatus implements BaseResponseStatus {
     MEMBER_ACCOUNT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER-001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     MEMBER_ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER-002", "잘 못 된 요청입니다."),
+    MEMBER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-003", "사용자 정보를 찾을 수 없습니다."),
     REFRESH_TOKEN_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REFRESH_TOKEN-001", "서버 내부 오류가 발생했습니다."),
     REFRESH_TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN-002", "만료된 요청 입니다.");
 

--- a/src/main/java/store/sonyk9919/api/domain/member/repository/MemberAccountRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/repository/MemberAccountRepository.java
@@ -1,5 +1,6 @@
 package store.sonyk9919.api.domain.member.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import store.sonyk9919.api.domain.auth.entity.OAuthProviderType;
 import store.sonyk9919.api.domain.member.entity.MemberAccount;
@@ -9,4 +10,7 @@ import java.util.Optional;
 public interface MemberAccountRepository extends JpaRepository<MemberAccount, Long> {
 
     Optional<MemberAccount> findByProviderIdAndType(String providerId, OAuthProviderType type);
+
+    @EntityGraph(attributePaths = { "profile" })
+    Optional<MemberAccount> findWithProfileById(Long id);
 }

--- a/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
@@ -23,6 +23,11 @@ public class MemberAccountService {
                 .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_BAD_REQUEST));
     }
 
+    public MemberAccount getMemberAccountWithProfile(Long memberAccountId) {
+        return memberAccountRepository.findWithProfileById(memberAccountId)
+                .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_BAD_REQUEST));
+    }
+
     @Transactional
     public MemberAccount createMemberAccount(OAuthUserInfoDto userInfo, OAuthProviderType type) {
         MemberAccount memberAccount = MemberAccount.from(userInfo, type, AccountRole.USER);

--- a/src/main/java/store/sonyk9919/api/domain/member/service/MemberRegisterFacade.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/MemberRegisterFacade.java
@@ -3,11 +3,15 @@ package store.sonyk9919.api.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.member.dto.MemberProfileResponseDto;
 import store.sonyk9919.api.domain.member.entity.MemberAccount;
 import store.sonyk9919.api.domain.member.entity.MemberProfile;
+import store.sonyk9919.api.domain.member.exception.MemberStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberRegisterFacade {
     private final MemberAccountService memberAccountService;
     private final MemberProfileService memberProfileService;
@@ -17,5 +21,16 @@ public class MemberRegisterFacade {
         MemberAccount account = memberAccountService.getMemberAccount(memberAccountId);
         MemberProfile profile = memberProfileService.createMemberProfile(nickname);
         account.registerMemberProfile(profile);
+    }
+
+    public MemberProfileResponseDto getProfile(Long memberAccountId) {
+        MemberAccount account = memberAccountService.getMemberAccountWithProfile(memberAccountId);
+        MemberProfile profile = account.getProfile();
+
+        if (profile == null) {
+            throw new CustomException(MemberStatus.MEMBER_PROFILE_NOT_FOUND);
+        }
+
+        return MemberProfileResponseDto.from(profile);
     }
 }

--- a/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
+++ b/src/main/java/store/sonyk9919/api/global/common/dto/ErrorStatus.java
@@ -11,6 +11,7 @@ public enum ErrorStatus implements BaseResponseStatus {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "COMMON_400_1", "요청 본문 형식이 올바르지 않습니다."),
     VALIDATION_FAIL(HttpStatus.BAD_REQUEST, "COMMON_400_2", "입력값이 올바르지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증되지 않은 요청입니다."),
     NO_PERMISSION(HttpStatus.FORBIDDEN, "COMMON_403", "접근 권한이 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"COMMON_405","지원하지 않는 HTTP 메소드 입니다."),
 

--- a/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/store/sonyk9919/api/global/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package store.sonyk9919.api.global.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -17,6 +20,7 @@ import org.springframework.web.context.request.async.AsyncRequestTimeoutExceptio
 import store.sonyk9919.api.global.common.dto.BaseResponse;
 import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 import store.sonyk9919.api.global.common.dto.ErrorStatus;
+
 
 @Slf4j
 @RestControllerAdvice
@@ -29,6 +33,20 @@ public class GlobalExceptionHandler {
         log.warn("CustomException occurred at {}: [{}] {}",
                 request.getRequestURI(), status.getCode(), e.getMessage());
         return BaseResponse.error(status, e.getMessage());
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<BaseResponse<Void>> handleAuthenticationException(AuthenticationException e, HttpServletRequest request) {
+        log.warn("[AUTH ERROR] Unauthorized access attempt. URI: {}, Method: {}, Message: {}",
+                request.getRequestURI(), request.getMethod(), e.getMessage());
+        return BaseResponse.error(ErrorStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<BaseResponse<Void>> handleAccessDeniedException(AccessDeniedException e, HttpServletRequest request) {
+        log.warn("[ACCESS DENIED] tried to access protected resource. URI: {}, Method: {}, Reason: {}",
+                request.getRequestURI(), request.getMethod(), e.getMessage());
+        return BaseResponse.error(ErrorStatus.NO_PERMISSION);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
@@ -13,7 +13,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 import store.sonyk9919.api.domain.auth.filter.JwtAuthenticationFilter;
+import store.sonyk9919.api.domain.member.entity.AccountRole;
 import store.sonyk9919.api.global.config.property.CorsProperty;
 
 @Configuration
@@ -25,14 +27,27 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) {
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, HandlerExceptionResolver handlerExceptionResolver) {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers(
+                                "/v1/oauth/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().hasAnyAuthority(AccountRole.USER.getKey(), AccountRole.ADMIN.getKey())
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) ->
+                                handlerExceptionResolver.resolveException(request, response, null, authException)
+                        )
+                        .accessDeniedHandler((request, response, accessDeniedException) ->
+                                handlerExceptionResolver.resolveException(request, response, null, accessDeniedException)
+                        )
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 주요 변경사항

### Feature
- 사용자 상세 정보를 확인할 수 있는 API를 작성하였습니다.
- 시큐리티 필터를 활성화 했습니다.

## 상세 설명

- 클라이언트에서 로그인 여부를 판단하기 위해 사용자 사용자 상세 정보를 확인할 수 있는 API를 추가했습니다.
- 시큐리티 필터를 활성화해 아래 경로 이외의 요청의 경우 반드시 인가자만 접근 가능합니다.
  - /v1/oauth/**
  - /swagger-ui/**
  - /v3/api-docs/**
- MemberProfile의 경우 추후 MemberIsland로 교체해주시면 될 것 같습니다.

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-331

## 참고사항
X