### PR TITLE
feat: 슬롯 조회 및 활성화

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingDetailDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingDetailDto.java
@@ -18,19 +18,14 @@ public class BuildingDetailDto {
 
     private ProductionInfoDto productionInfo;
 
-    public static BuildingDetailDto from(Building building) {
-        if (building == null) return null;
-
-        BuildingMetadata metadata = building.getBuildingMetadata();
-        int level = building.getCurrentLevel();
-
+    public static BuildingDetailDto of(Building building, BuildingMetadata metadata, ProductionInfoDto productionInfo) {
         return new BuildingDetailDto(
                 building.getId(),
                 metadata.getName(),
                 metadata.getCategory().name(),
                 metadata.getModel(),
-                level,
-                ProductionInfoDto.from(building, metadata.getYieldForLevel(level))
+                building.getCurrentLevel(),
+                productionInfo
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingDetailDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingDetailDto.java
@@ -1,0 +1,36 @@
+package store.sonyk9919.api.domain.building.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.building.entity.Building;
+import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BuildingDetailDto {
+
+    private Long buildingId;
+    private String name;
+    private String category;
+    private String model;
+    private int currentLevel;
+
+    private ProductionInfoDto productionInfo;
+
+    public static BuildingDetailDto from(Building building) {
+        if (building == null) return null;
+
+        BuildingMetadata metadata = building.getBuildingMetadata();
+        int level = building.getCurrentLevel();
+
+        return new BuildingDetailDto(
+                building.getId(),
+                metadata.getName(),
+                metadata.getCategory().name(),
+                metadata.getModel(),
+                level,
+                ProductionInfoDto.from(building, metadata.getYieldForLevel(level))
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import store.sonyk9919.api.domain.building.entity.Building;
+import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,14 +19,12 @@ public class BuildingInfoDto {
     private int currentLevel;
     private boolean operating;
 
-    public static BuildingInfoDto from(Building building) {
-        if (building == null) return null;
-
+    public static BuildingInfoDto of(Building building, BuildingMetadata metadata) {
         return new BuildingInfoDto(
                 building.getId(),
-                building.getBuildingMetadata().getName(),
-                building.getBuildingMetadata().getCategory().name(),
-                building.getBuildingMetadata().getModel(),
+                metadata.getName(),
+                metadata.getCategory().name(),
+                metadata.getModel(),
                 building.getCurrentLevel(),
                 building.isOperating(LocalDateTime.now())
         );

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
@@ -1,0 +1,33 @@
+package store.sonyk9919.api.domain.building.dto;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.building.entity.Building;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BuildingInfoDto {
+
+    private Long buildingId;
+    private String buildingName;
+    private String category;
+    private String model;
+
+    private int currentLevel;
+    private boolean operating;
+
+    public static BuildingInfoDto from(Building building) {
+        if (building == null) return null;
+
+        return new BuildingInfoDto(
+                building.getId(),
+                building.getBuildingMetadata().getName(),
+                building.getBuildingMetadata().getCategory().name(),
+                building.getBuildingMetadata().getModel(),
+                building.getCurrentLevel(),
+                building.isOperating(LocalDateTime.now())
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/ProductionInfoDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/ProductionInfoDto.java
@@ -1,0 +1,27 @@
+package store.sonyk9919.api.domain.building.dto;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.building.entity.Building;
+import store.sonyk9919.api.domain.building.entity.BuildingYield;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductionInfoDto {
+    private int pph;
+    private boolean operating;
+    private LocalDateTime lastCollectedAt;
+    private LocalDateTime fuelExpiredAt;
+
+    public static ProductionInfoDto from(Building building, BuildingYield yield) {
+        if (!building.getBuildingMetadata().isProductionType()) return null;
+        return new ProductionInfoDto(
+                yield.getPph(),
+                building.isOperating(LocalDateTime.now()),
+                building.getLastCollectedAt(),
+                building.getFuelExpiredAt()
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/ProductionInfoDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/ProductionInfoDto.java
@@ -15,8 +15,7 @@ public class ProductionInfoDto {
     private LocalDateTime lastCollectedAt;
     private LocalDateTime fuelExpiredAt;
 
-    public static ProductionInfoDto from(Building building, BuildingYield yield) {
-        if (!building.getBuildingMetadata().isProductionType()) return null;
+    public static ProductionInfoDto of(Building building, BuildingYield yield) {
         return new ProductionInfoDto(
                 yield.getPph(),
                 building.isOperating(LocalDateTime.now()),

--- a/src/main/java/store/sonyk9919/api/domain/island/entity/LevelSpec.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/LevelSpec.java
@@ -22,4 +22,7 @@ public class LevelSpec {
     private int recyclingContributionExpLimit;
 
     private Integer itemContributionExpMin;
+
+    @Column(nullable = false)
+    private int maxSlotCount;
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/exception/ResourceStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/exception/ResourceStatus.java
@@ -1,0 +1,16 @@
+package store.sonyk9919.api.domain.island.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResourceStatus implements BaseResponseStatus {
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE-001", "존재하지 않는 재화입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/LevelSpecRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/LevelSpecRepository.java
@@ -1,0 +1,8 @@
+package store.sonyk9919.api.domain.island.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
+
+public interface LevelSpecRepository extends JpaRepository<LevelSpec, Integer> {
+    LevelSpec findByLevel(int level);
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/MemberIslandRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/MemberIslandRepository.java
@@ -1,11 +1,10 @@
 package store.sonyk9919.api.domain.island.repository;
 
 import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
-
-import java.util.Optional;
 
 public interface MemberIslandRepository extends JpaRepository<MemberIsland, Long> {
 

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/MemberResourceRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/MemberResourceRepository.java
@@ -1,10 +1,15 @@
 package store.sonyk9919.api.domain.island.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.entity.MemberResource;
 import store.sonyk9919.api.domain.island.entity.ResourceType;
 
 public interface MemberResourceRepository extends JpaRepository<MemberResource, Long> {
-    MemberResource findByIslandAndResourceType(MemberIsland island, ResourceType type);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<MemberResource> findWithLockByIslandAndResourceType(MemberIsland island, ResourceType type);
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/MemberResourceRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/MemberResourceRepository.java
@@ -1,0 +1,10 @@
+package store.sonyk9919.api.domain.island.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+
+public interface MemberResourceRepository extends JpaRepository<MemberResource, Long> {
+    MemberResource findByIslandAndResourceType(MemberIsland island, ResourceType type);
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -46,9 +46,4 @@ public class MemberIslandRegistryService {
                 .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
         return MemberIslandDto.from(island);
     }
-
-    public MemberIsland getIslandWithWriteLock(Long memberAccountId) {
-        return memberIslandRepository.findWithWriteLockByMemberAccountId(memberAccountId)
-                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
-    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -46,4 +46,9 @@ public class MemberIslandRegistryService {
                 .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
         return MemberIslandDto.from(island);
     }
+
+    public MemberIsland getIslandWithWriteLock(Long memberAccountId) {
+        return memberIslandRepository.findWithWriteLockByMemberAccountId(memberAccountId)
+                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
+    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -9,6 +9,7 @@ import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
 import store.sonyk9919.api.domain.member.entity.MemberAccount;
 import store.sonyk9919.api.domain.member.service.MemberAccountService;
+import store.sonyk9919.api.domain.slot.service.SlotSetupService;
 import store.sonyk9919.api.global.common.exception.CustomException;
 
 @Service
@@ -18,12 +19,15 @@ public class MemberIslandRegistryService {
 
     private final MemberIslandRepository memberIslandRepository;
     private final MemberAccountService memberAccountService;
+    private final SlotSetupService slotSetupService;
 
     @Transactional
     public MemberIsland create(Long memberAccountId, String nickname) {
         MemberAccount account = memberAccountService.getMemberAccount(memberAccountId);
         MemberIsland island = MemberIsland.create(nickname, account);
+
         memberIslandRepository.save(island);
+        slotSetupService.setupSlots(island);
         return island;
     }
 

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSlotService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSlotService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.entity.MemberResource;
 import store.sonyk9919.api.domain.island.entity.ResourceType;
+import store.sonyk9919.api.domain.island.exception.ResourceStatus;
 import store.sonyk9919.api.domain.island.repository.MemberResourceRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +20,8 @@ public class ResourceSlotService {
     @Transactional
     public MemberResource subtractShell(MemberIsland island, long amount) {
         MemberResource shellResource = memberResourceRepository
-                .findByIslandAndResourceType(island, ResourceType.SHELL);
+                .findWithLockByIslandAndResourceType(island, ResourceType.SHELL)
+                .orElseThrow(() -> new CustomException(ResourceStatus.RESOURCE_NOT_FOUND));
 
         shellResource.subtractAmount(amount);
         return shellResource;

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSlotService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSlotService.java
@@ -1,0 +1,26 @@
+package store.sonyk9919.api.domain.island.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+import store.sonyk9919.api.domain.island.repository.MemberResourceRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ResourceSlotService {
+
+    private final MemberResourceRepository memberResourceRepository;
+
+    @Transactional
+    public MemberResource subtractShell(MemberIsland island, long amount) {
+        MemberResource shellResource = memberResourceRepository
+                .findByIslandAndResourceType(island, ResourceType.SHELL);
+
+        shellResource.subtractAmount(amount);
+        return shellResource;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
@@ -1,6 +1,10 @@
 package store.sonyk9919.api.domain.slot.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +19,11 @@ import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
 import store.sonyk9919.api.domain.slot.service.SlotActivateService;
 import store.sonyk9919.api.domain.slot.service.SlotQueryService;
+import store.sonyk9919.api.global.common.dto.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/slot")
+@RequestMapping("/v1/slots")
 public class SlotController {
 
     private final SlotQueryService slotQueryService;
@@ -28,6 +33,12 @@ public class SlotController {
             summary = "유저의 전체 슬롯 조회",
             description = "현재 로그인된 유저의 섬에 있는 모든 슬롯의 상태와 배치된 건물 기본 정보를 조회합니다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "슬롯 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @ApiResponse(responseCode = "404", description = "섬을 찾을 수 없음 (ISLAND-003)",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
     @GetMapping
     public List<SlotResponseDto> searchAllSlots(@AuthMember AuthMemberDto authMember) {
         return slotQueryService.getAllSlot(authMember.getId());
@@ -37,6 +48,12 @@ public class SlotController {
             summary = "특정 슬롯 상세 조회",
             description = "선택한 슬롯 번호에 대한 상세 정보(생산량, 남은 시간, 효과 등)를 조회합니다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "슬롯 상세 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 슬롯 번호 (SLOT-004)"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @ApiResponse(responseCode = "404", description = "섬을 찾을 수 없음 (ISLAND-003)")
+    })
     @GetMapping("/{slotNumber}")
     public SlotDetailResponseDto searchSlotDetail(
             @AuthMember AuthMemberDto authMember,
@@ -49,6 +66,12 @@ public class SlotController {
             summary = "슬롯 활성화",
             description = "현재 레벨과 활성화된 슬롯 개수에 따라 필요 조개를 차감하고 해당 슬롯을 활성화합니다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "슬롯 활성화 성공, 차감 후 남은 조개 수량 반환"),
+            @ApiResponse(responseCode = "400", description = "이미 활성화된 슬롯 (SLOT-001), 최대 활성화 개수 초과 (SLOT-005), 조개 잔액 부족 (ISLAND-002)"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 슬롯 번호 (SLOT-004), 섬을 찾을 수 없음 (ISLAND-003)")
+    })
     @PostMapping("/activate/{slotNumber}")
     public SlotActivateResponseDto activateSlot(
             @AuthMember AuthMemberDto authMember,

--- a/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
@@ -1,0 +1,34 @@
+package store.sonyk9919.api.domain.slot.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.entity.AuthMember;
+import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
+import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
+import store.sonyk9919.api.domain.slot.service.SlotQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/slot")
+public class SlotController {
+
+    private final SlotQueryService slotQueryService;
+
+    @GetMapping
+    public List<SlotResponseDto> searchAllSlots(@AuthMember AuthMemberDto authMember) {
+        return slotQueryService.getAllSlot(authMember.getId());
+    }
+
+    @GetMapping("/{slotNumber}")
+    public SlotDetailResponseDto searchSlotDetail(
+            @AuthMember AuthMemberDto authMember,
+            @PathVariable Integer slotNumber
+    ) {
+        return slotQueryService.getSlotDetail(authMember.getId(), slotNumber);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
@@ -1,5 +1,6 @@
 package store.sonyk9919.api.domain.slot.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +13,8 @@ import store.sonyk9919.api.domain.auth.entity.AuthMember;
 import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
-import store.sonyk9919.api.domain.slot.service.SlotQueryService;
 import store.sonyk9919.api.domain.slot.service.SlotActivateService;
+import store.sonyk9919.api.domain.slot.service.SlotQueryService;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,11 +24,19 @@ public class SlotController {
     private final SlotQueryService slotQueryService;
     private final SlotActivateService slotActivateService;
 
+    @Operation(
+            summary = "유저의 전체 슬롯 조회",
+            description = "현재 로그인된 유저의 섬에 있는 모든 슬롯의 상태와 배치된 건물 기본 정보를 조회합니다."
+    )
     @GetMapping
     public List<SlotResponseDto> searchAllSlots(@AuthMember AuthMemberDto authMember) {
         return slotQueryService.getAllSlot(authMember.getId());
     }
 
+    @Operation(
+            summary = "특정 슬롯 상세 조회",
+            description = "선택한 슬롯 번호에 대한 상세 정보(생산량, 남은 시간, 효과 등)를 조회합니다."
+    )
     @GetMapping("/{slotNumber}")
     public SlotDetailResponseDto searchSlotDetail(
             @AuthMember AuthMemberDto authMember,
@@ -36,6 +45,10 @@ public class SlotController {
         return slotQueryService.getSlotDetail(authMember.getId(), slotNumber);
     }
 
+    @Operation(
+            summary = "슬롯 활성화",
+            description = "현재 레벨과 활성화된 슬롯 개수에 따라 필요 조개를 차감하고 해당 슬롯을 활성화합니다."
+    )
     @PostMapping("/activate/{slotNumber}")
     public SlotActivateResponseDto activateSlot(
             @AuthMember AuthMemberDto authMember,

--- a/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
@@ -4,13 +4,16 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
+import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
 import store.sonyk9919.api.domain.slot.service.SlotQueryService;
+import store.sonyk9919.api.domain.slot.service.SlotActivateService;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ import store.sonyk9919.api.domain.slot.service.SlotQueryService;
 public class SlotController {
 
     private final SlotQueryService slotQueryService;
+    private final SlotActivateService slotActivateService;
 
     @GetMapping
     public List<SlotResponseDto> searchAllSlots(@AuthMember AuthMemberDto authMember) {
@@ -30,5 +34,13 @@ public class SlotController {
             @PathVariable Integer slotNumber
     ) {
         return slotQueryService.getSlotDetail(authMember.getId(), slotNumber);
+    }
+
+    @PostMapping("/activate/{slotNumber}")
+    public SlotActivateResponseDto activateSlot(
+            @AuthMember AuthMemberDto authMember,
+            @PathVariable Integer slotNumber
+    ) {
+      return slotActivateService.activate(authMember.getId(), slotNumber);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotActivateResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotActivateResponseDto.java
@@ -1,0 +1,12 @@
+package store.sonyk9919.api.domain.slot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SlotActivateResponseDto {
+
+    private Integer slotNumber;
+    private long remainingShell;
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
@@ -1,0 +1,24 @@
+package store.sonyk9919.api.domain.slot.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.building.dto.BuildingDetailDto;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SlotDetailResponseDto {
+
+    private Integer slotNumber;
+    private boolean activated;
+    private BuildingDetailDto building;
+
+    public static SlotDetailResponseDto from(Slot slot) {
+        return new SlotDetailResponseDto(
+                slot.getSlotNumber(),
+                slot.isActivated(),
+                BuildingDetailDto.from(slot.getBuilding())
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
@@ -14,11 +14,11 @@ public class SlotDetailResponseDto {
     private boolean activated;
     private BuildingDetailDto building;
 
-    public static SlotDetailResponseDto from(Slot slot) {
+    public static SlotDetailResponseDto of(Slot slot, BuildingDetailDto buildingDto) {
         return new SlotDetailResponseDto(
                 slot.getSlotNumber(),
                 slot.isActivated(),
-                BuildingDetailDto.from(slot.getBuilding())
+                buildingDto
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
@@ -1,0 +1,24 @@
+package store.sonyk9919.api.domain.slot.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.building.dto.BuildingInfoDto;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SlotResponseDto {
+
+    private Integer slotNumber;
+    private boolean activated;
+    private BuildingInfoDto building;
+
+    public static SlotResponseDto from(Slot slot) {
+        return new SlotResponseDto(
+                slot.getSlotNumber(),
+                slot.isActivated(),
+                BuildingInfoDto.from(slot.getBuilding())
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
@@ -14,11 +14,11 @@ public class SlotResponseDto {
     private boolean activated;
     private BuildingInfoDto building;
 
-    public static SlotResponseDto from(Slot slot) {
+    public static SlotResponseDto of(Slot slot, BuildingInfoDto buildingInfo) {
         return new SlotResponseDto(
                 slot.getSlotNumber(),
                 slot.isActivated(),
-                BuildingInfoDto.from(slot.getBuilding())
+                buildingInfo
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/entity/Slot.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/entity/Slot.java
@@ -50,8 +50,8 @@ public class Slot {
         this.activated = false;
     }
 
-    public static Slot of(MemberIsland member, int slotNumber){
-        return new Slot(member, slotNumber);
+    public static Slot of(MemberIsland island, int slotNumber){
+        return new Slot(island, slotNumber);
     }
 
     public void activate() {

--- a/src/main/java/store/sonyk9919/api/domain/slot/entity/SlotUnlockPolicy.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/entity/SlotUnlockPolicy.java
@@ -1,0 +1,14 @@
+package store.sonyk9919.api.domain.slot.entity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SlotUnlockPolicy {
+    private static final int BASE_COST = 1_000;
+    private static final double COST_PER_ACTIVE_SLOT = 1.5;
+
+    public static int costFor(int activeCount) {
+        return (int) (BASE_COST * Math.pow(COST_PER_ACTIVE_SLOT, activeCount));
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/entity/SlotUnlockPolicy.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/entity/SlotUnlockPolicy.java
@@ -8,6 +8,8 @@ public class SlotUnlockPolicy {
     private static final int BASE_COST = 1_000;
     private static final double COST_PER_ACTIVE_SLOT = 1.5;
 
+    public static final int MAX_SLOT_COUNT = 7;
+
     public static int costFor(int activeCount) {
         return (int) (BASE_COST * Math.pow(COST_PER_ACTIVE_SLOT, activeCount));
     }

--- a/src/main/java/store/sonyk9919/api/domain/slot/exception/SlotStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/exception/SlotStatus.java
@@ -10,7 +10,8 @@ import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
 public enum SlotStatus implements BaseResponseStatus{
     SLOT_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "SLOT-001", "이미 활성화된 슬롯입니다."),
     SLOT_NOT_ACTIVATED(HttpStatus.BAD_REQUEST, "SLOT-002", "비활성화된 슬롯에는 건물을 지을 수 없습니다."),
-    SLOT_ALREADY_BUILT(HttpStatus.BAD_REQUEST, "SLOT-003", "이미 건물이 배치된 슬롯입니다.");
+    SLOT_ALREADY_BUILT(HttpStatus.BAD_REQUEST, "SLOT-003", "이미 건물이 배치된 슬롯입니다."),
+    SLOT_NOT_FOUND(HttpStatus.BAD_REQUEST, "SLOT-004", "존재하지 않는 슬롯입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/domain/slot/exception/SlotStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/exception/SlotStatus.java
@@ -11,7 +11,9 @@ public enum SlotStatus implements BaseResponseStatus{
     SLOT_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "SLOT-001", "이미 활성화된 슬롯입니다."),
     SLOT_NOT_ACTIVATED(HttpStatus.BAD_REQUEST, "SLOT-002", "비활성화된 슬롯에는 건물을 지을 수 없습니다."),
     SLOT_ALREADY_BUILT(HttpStatus.BAD_REQUEST, "SLOT-003", "이미 건물이 배치된 슬롯입니다."),
-    SLOT_NOT_FOUND(HttpStatus.BAD_REQUEST, "SLOT-004", "존재하지 않는 슬롯입니다.");
+    SLOT_NOT_FOUND(HttpStatus.BAD_REQUEST, "SLOT-004", "존재하지 않는 슬롯입니다."),
+
+    EXCEED_MAX_SLOT_FOR_LEVEL(HttpStatus.BAD_REQUEST, "SLOT-005", "현재 레벨에서 최대 활성화 개수를 초과했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
@@ -9,4 +9,6 @@ import store.sonyk9919.api.domain.slot.entity.Slot;
 public interface SlotRepository extends JpaRepository<Slot, Long> {
     List<Slot> findAllByIsland(MemberIsland island);
     Optional<Slot> findByIslandAndSlotNumber(MemberIsland island, Integer slotNumber);
+
+    int countByIslandAndActivatedTrue(MemberIsland island);
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
@@ -1,0 +1,12 @@
+package store.sonyk9919.api.domain.slot.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+
+public interface SlotRepository extends JpaRepository<Slot, Long> {
+    List<Slot> findAllByIsland(MemberIsland island);
+    Optional<Slot> findByIslandAndSlotNumber(MemberIsland island, Integer slotNumber);
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/repository/SlotRepository.java
@@ -2,12 +2,17 @@ package store.sonyk9919.api.domain.slot.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.slot.entity.Slot;
 
 public interface SlotRepository extends JpaRepository<Slot, Long> {
+
+    @EntityGraph(attributePaths = {"building", "building.buildingMetadata"})
     List<Slot> findAllByIsland(MemberIsland island);
+
+    @EntityGraph(attributePaths = {"building", "building.buildingMetadata"})
     Optional<Slot> findByIslandAndSlotNumber(MemberIsland island, Integer slotNumber);
 
     int countByIslandAndActivatedTrue(MemberIsland island);

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
@@ -1,0 +1,43 @@
+package store.sonyk9919.api.domain.slot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.island.service.ResourceSlotService;
+import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+import store.sonyk9919.api.domain.slot.entity.SlotUnlockPolicy;
+import store.sonyk9919.api.domain.slot.exception.SlotStatus;
+import store.sonyk9919.api.domain.slot.repository.SlotRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SlotActivateService {
+
+    private final SlotRepository slotRepository;
+    private final MemberIslandRegistryService memberIslandService;
+    private final ResourceSlotService resourceSlotService;
+
+    public SlotActivateResponseDto activate(Long memberId, Integer slotNumber) {
+        MemberIsland island = memberIslandService.getIsland(memberId);
+
+        Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
+                .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
+
+        int activeCount = slotRepository.countByIslandAndActivatedTrue(island);
+        int cost = SlotUnlockPolicy.costFor(activeCount);
+
+        MemberResource updatedShell = resourceSlotService.subtractShell(island, cost);
+        slot.activate();
+
+        return new SlotActivateResponseDto(
+                slot.getSlotNumber(),
+                updatedShell.getAmount()
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
@@ -27,7 +27,7 @@ public class SlotActivateService {
     private final LevelSpecRepository levelSpecRepository;
 
     public SlotActivateResponseDto activate(Long memberId, Integer slotNumber) {
-        MemberIsland island = memberIslandService.getIsland(memberId);
+        MemberIsland island = memberIslandService.getIslandWithWriteLock(memberId);
         Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
 

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
@@ -3,8 +3,10 @@ package store.sonyk9919.api.domain.slot.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.repository.LevelSpecRepository;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.island.service.ResourceSlotService;
 import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
@@ -22,22 +24,29 @@ public class SlotActivateService {
     private final SlotRepository slotRepository;
     private final MemberIslandRegistryService memberIslandService;
     private final ResourceSlotService resourceSlotService;
+    private final LevelSpecRepository levelSpecRepository;
 
     public SlotActivateResponseDto activate(Long memberId, Integer slotNumber) {
         MemberIsland island = memberIslandService.getIsland(memberId);
-
         Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
 
         int activeCount = slotRepository.countByIslandAndActivatedTrue(island);
-        int cost = SlotUnlockPolicy.costFor(activeCount);
+        validateSlotUnlockLevel(island.getLevel(), activeCount);
 
-        MemberResource updatedShell = resourceSlotService.subtractShell(island, cost);
+        MemberResource updatedShell = resourceSlotService.subtractShell(
+                island, SlotUnlockPolicy.costFor(activeCount)
+        );
         slot.activate();
 
-        return new SlotActivateResponseDto(
-                slot.getSlotNumber(),
-                updatedShell.getAmount()
-        );
+        return new SlotActivateResponseDto(slot.getSlotNumber(), updatedShell.getAmount());
+    }
+
+    private void validateSlotUnlockLevel(int currentLevel, int activeCount) {
+        LevelSpec currentLevelSpec = levelSpecRepository.findByLevel(currentLevel);
+
+        if (activeCount >= currentLevelSpec.getMaxSlotCount()) {
+            throw new CustomException(SlotStatus.EXCEED_MAX_SLOT_FOR_LEVEL);
+        }
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -25,8 +25,8 @@ public class SlotQueryService {
     public List<SlotResponseDto> getAllSlot(Long memberId) {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
-        List<Slot> slots = slotRepository.findAllByIsland(island);
-        return slots.stream()
+        return slotRepository.findAllByIsland(island)
+                .stream()
                 .map(SlotResponseDto::from)
                 .collect(Collectors.toList());
     }
@@ -34,8 +34,8 @@ public class SlotQueryService {
     public SlotDetailResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
-        Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
+        return slotRepository.findByIslandAndSlotNumber(island, slotNumber)
+                .map(SlotDetailResponseDto::from)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
-        return SlotDetailResponseDto.from(slot);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -1,0 +1,41 @@
+package store.sonyk9919.api.domain.slot.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
+import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+import store.sonyk9919.api.domain.slot.exception.SlotStatus;
+import store.sonyk9919.api.domain.slot.repository.SlotRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SlotQueryService {
+
+    private final SlotRepository slotRepository;
+    private final MemberIslandRegistryService memberIslandService;
+
+    public List<SlotResponseDto> getAllSlot(Long memberId) {
+        MemberIsland island = memberIslandService.getIsland(memberId);
+
+        List<Slot> slots = slotRepository.findAllByIsland(island);
+        return slots.stream()
+                .map(SlotResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public SlotDetailResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
+        MemberIsland island = memberIslandService.getIsland(memberId);
+
+        Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
+                .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
+        return SlotDetailResponseDto.from(slot);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -5,11 +5,16 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.building.dto.BuildingDetailDto;
+import store.sonyk9919.api.domain.building.dto.BuildingInfoDto;
+import store.sonyk9919.api.domain.building.dto.ProductionInfoDto;
+import store.sonyk9919.api.domain.building.entity.Building;
+import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
+import store.sonyk9919.api.domain.building.entity.BuildingYield;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
-import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.exception.SlotStatus;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.global.common.exception.CustomException;
@@ -27,7 +32,7 @@ public class SlotQueryService {
 
         return slotRepository.findAllByIsland(island)
                 .stream()
-                .map(SlotResponseDto::from)
+                .map(slot -> SlotResponseDto.of(slot, mapToBuildingInfo(slot.getBuilding())))
                 .collect(Collectors.toList());
     }
 
@@ -35,7 +40,26 @@ public class SlotQueryService {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
         return slotRepository.findByIslandAndSlotNumber(island, slotNumber)
-                .map(SlotDetailResponseDto::from)
+                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(slot.getBuilding())))
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
+    }
+
+    private BuildingInfoDto mapToBuildingInfo(Building building){
+        if (building == null) return null;
+
+        return BuildingInfoDto.of(building, building.getBuildingMetadata());
+    }
+
+    private BuildingDetailDto mapToBuildingDetail(Building building) {
+        if (building == null) return null;
+
+        BuildingMetadata metadata = building.getBuildingMetadata();
+        BuildingYield yield = metadata.getYieldForLevel(building.getCurrentLevel());
+
+        ProductionInfoDto productionInfoDto = metadata.isProductionType()
+                ? ProductionInfoDto.of(building, yield)
+                : null;
+
+        return BuildingDetailDto.of(building, metadata, productionInfoDto);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
@@ -17,6 +18,7 @@ public class SlotSetupService {
 
     private final SlotRepository slotRepository;
 
+    @Transactional
     public void setupSlots(MemberIsland island) {
         List<Slot> initialSlots = IntStream.rangeClosed(1, MAX_SLOT_COUNT)
                 .mapToObj(i -> Slot.of(island, i))

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
@@ -1,0 +1,26 @@
+package store.sonyk9919.api.domain.slot.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+import store.sonyk9919.api.domain.slot.repository.SlotRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SlotSetupService {
+
+    private static final int MAX_SLOT_COUNT = 7;
+    private final SlotRepository slotRepository;
+
+    public void setupSlots(MemberIsland island) {
+        List<Slot> initialSlots = IntStream.rangeClosed(1, MAX_SLOT_COUNT)
+                .mapToObj(i -> Slot.of(island, i))
+                .collect(Collectors.toList());
+
+        slotRepository.saveAll(initialSlots);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotSetupService.java
@@ -1,5 +1,7 @@
 package store.sonyk9919.api.domain.slot.service;
 
+import static store.sonyk9919.api.domain.slot.entity.SlotUnlockPolicy.MAX_SLOT_COUNT;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -13,7 +15,6 @@ import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 @RequiredArgsConstructor
 public class SlotSetupService {
 
-    private static final int MAX_SLOT_COUNT = 7;
     private final SlotRepository slotRepository;
 
     public void setupSlots(MemberIsland island) {

--- a/src/main/resources/db/level_spec.sql
+++ b/src/main/resources/db/level_spec.sql
@@ -1,7 +1,7 @@
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (1, 500, 500, null);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (2, 1500, 1000, null);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (3, 3000, 1000, 500);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (4, 4500, 500, 1000);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (5, 6250, 750, 1000);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (6, 8250, 1000, 1000);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min) values (7, 11250, 1500, 1000);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (1, 500, 500, null, 2);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (2, 1500, 1000, null, 3);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (3, 3000, 1000, 500, 4);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (4, 4500, 500, 1000, 5);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (5, 6250, 750, 1000, 6);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (6, 8250, 1000, 1000, 7);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, item_contribution_exp_min, max_slot_count) values (7, 11250, 1500, 1000, 7);


### PR DESCRIPTION
## 주요 변경사항

- 유저의 섬 내 슬롯 조회, 특정 슬롯 활성화 API 작성

### Feature
- 유저 슬롯 전체, 개별 조회 API 구현
- 슬롯 활성화 API 구현
- 현재 활성화된 슬롯 개수를 기반으로 비용 적용
- 슬롯 활성화 시 필요 재화(조개) 잔여량 검증 및 차감


## 상세 설명

###  슬롯 조회
- **전체 조회:** MemberIsland에 존재하는 전체 슬롯의 정보(슬롯 번호, 활성화 상태, 건설된 건물 등)를 리스트 형태로 반환합니다.
- **개별 조회:** 특정 `slotNumber`를 파라미터로 받아 해당 슬롯의 상세 정보를 조회합니다.
### 슬롯 활성화
- **비용 계산**: 제곱 곱셈 형태로 식을 적용해서 후반부로 갈 수록 비용이 증가하게 했습니다.
- **검증 및 차감**: 이전 재화 엔티티를 이용해산출된 비용과 유저가 현재 보유한 조개 수량을 비교 검증합니다.


## Jira 링크

- https://untitled.atlassian.net/browse/KAN-341

## 참고사항

- 우선 최대 슬롯을 7개로 잡았는데 게임 화면 만들면서 슬롯 최대 개수는 충분히 바뀔 것 같아서 수정되는 걸로 맞추겠습니다!

- 슬롯 해금 비용:


현재 활성화된 슬롯 수 | 해금하려는 슬롯 | 1000(기본) × 1.5^n | 필요 재화(조개)
-- | -- | -- | --
0개 | 1번 슬롯 | 1,000 × (1.5 ^ 0) | 1000
1개 | 2번 슬롯 | 1,000 × (1.5 ^ 1) | 1,500
2개 | 3번 슬롯 | 1,000 × (1.5 ^ 2) | 2,250
3개 | 4번 슬롯 | 1,000 × (1.5 ^ 3) | 3,375
4개 | 5번 슬롯 | 1,000 × (1.5 ^ 4) | 5,062
5개 | 6번 슬롯 | 1,000 × (1.5 ^ 5) | 7,593
6개 | 7번 슬롯 | 1,000 × (1.5 ^ 6) | 11,390



- 전체 슬롯 조회
```json
[
  {
    "slotNumber": 1,
    "activated": true,
    "building": {
      "buildingId": 1,
      "buildingName": "풍력 발전소",
      "category": "PRODUCTION",
      "model": "model_wind_01",
      "currentLevel": 1,
      "operating": true
    }
  },
  {
    "slotNumber": 2,
    "activated": false,
    "building": null
  }
]
```

- 슬롯 개별 조회

```json
{
  "slotNumber": 1,
  "activated": true,
  "building": {
    "buildingId": 1,
    "name": "풍력 발전소",
    "category": "PRODUCTION",
    "model": "model_wind_01",
    "currentLevel": 1,
    "productionInfo": {
      "pph": 5,
      "operating": true,
      "lastCollectedAt": "2026-04-13T15:30:00",
      "fuelExpiredAt": "2026-04-13T15:30:00"
    }
  }
}
```
