### PR TITLE
feat: 섬 생성 시 생성된 섬 정보를 반환

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
@@ -29,11 +29,11 @@ public class MemberIslandController {
     })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public void createIsland(
+    public MemberIslandDto createIsland(
             @Parameter(hidden = true) @AuthMember AuthMemberDto authMember,
             @Validated @RequestBody MemberIslandCreateRequestDto requestDto
     ) {
-        memberIslandRegistryService.create(authMember.getId(), requestDto.getNickname());
+        return memberIslandRegistryService.createDto(authMember.getId(), requestDto.getNickname());
     }
 
     @Operation(summary = "섬 정보 조회", description = "회원의 섬 정보를 상세 조회합니다.")

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -23,12 +23,20 @@ public class MemberIslandRegistryService {
 
     @Transactional
     public MemberIsland create(Long memberAccountId, String nickname) {
+        return createEntity(memberAccountId, nickname);
+    }
+
+    @Transactional
+    public MemberIslandDto createDto(Long memberAccountId, String nickname) {
+        MemberIsland island = createEntity(memberAccountId, nickname);
+        return MemberIslandDto.from(island);
+    }
+
+    private MemberIsland createEntity(Long memberAccountId, String nickname) {
         MemberAccount account = memberAccountService.getMemberAccount(memberAccountId);
         MemberIsland island = MemberIsland.create(nickname, account);
-
-        memberIslandRepository.save(island);
         slotSetupService.setupSlots(island);
-        return island;
+        return memberIslandRepository.save(island);
     }
 
     public MemberIsland getIsland(Long memberAccountId) {

--- a/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                 "/v1/oauth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
+                                "/swagger-ui.html",
                                 "/h2-console/**"
                         ).permitAll()
                         .anyRequest().hasAnyAuthority(AccountRole.USER.getKey(), AccountRole.ADMIN.getKey())

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -58,7 +58,7 @@ jwt:
 
 security:
   cookie:
-    sameSite: Lax
+    sameSite: None
     domain: .sonyk9919.store
 
   cors:


### PR DESCRIPTION
## 주요 변경사항

### Feature
- 섬 생성 시 생성된 섬 정보를 반환하도록 수정하였습니다.

### Chore
- 개발 편의 성을 위해 same-site 설정을 None으로 변경하였습니다.

## 상세 설명

- 현재 운영 서버=개발서버 이기 때문에 보안과 관련하여 모순이 발생할 수 밖에 없는 상황입니다.
- 따라서 금번 스프린트의 인프라 개선 작업에서 flyway 도입과 함께 운영과 스테이징 서버를 분리할 예정입니다.
- 이때, ddl-create 설정 및 same-site 설정을 각 환경에 맞게 다시 설정할 예정이니 참고 바랍니다. 

## 참고사항

- 리뷰 받을 만한 사항은 없다고 생각해서 병합하겠습니다. 혹시 궁금한 점이 있다면 PR 스레드, 디코, 카톡으로 전달 주시면 될 것 같아요.
