### PR TITLE
feat: 상점 도메인 신규 생성 및 아이템 목록 조회 API 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
@@ -1,0 +1,11 @@
+package store.sonyk9919.api.domain.island.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+
+public interface IslandItemUsageRepository extends JpaRepository<IslandItemUsage, Long> {
+
+    List<IslandItemUsage> findAllByIsland(MemberIsland island);
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/ItemRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/ItemRepository.java
@@ -1,0 +1,10 @@
+package store.sonyk9919.api.domain.island.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import store.sonyk9919.api.domain.island.entity.Item;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    List<Item> findAllByOrderByIdAsc();
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemCache.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemCache.java
@@ -1,0 +1,20 @@
+package store.sonyk9919.api.domain.island.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.repository.ItemRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ItemCache {
+
+    private final ItemRepository itemRepository;
+
+    @Cacheable(cacheNames = "items", key = "'all'")
+    public List<Item> getAll() {
+        return itemRepository.findAllByOrderByIdAsc();
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/controller/ShopController.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/controller/ShopController.java
@@ -1,0 +1,39 @@
+package store.sonyk9919.api.domain.shop.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.entity.AuthMember;
+import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+import store.sonyk9919.api.domain.shop.service.ShopService;
+
+@RestController
+@RequestMapping("/v1/shops")
+@RequiredArgsConstructor
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @Operation(summary = "상점 아이템 목록 조회", description = "상점에서 구매 가능한 아이템 목록과 사용자의 현재 구매 현황을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "섬을 찾을 수 없음")
+    })
+    @GetMapping("/items")
+    @ResponseStatus(HttpStatus.OK)
+    public List<ShopItemResponse> getItems(
+            @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
+    ) {
+        return shopService.getItems(authMember.getId());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/dto/ShopItemResponse.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/dto/ShopItemResponse.java
@@ -1,0 +1,33 @@
+package store.sonyk9919.api.domain.shop.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.island.entity.Item;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ShopItemResponse {
+
+    private final Long itemId;
+    private final String name;
+    private final int price;
+    private final int maxCount;
+    private final long currentCount;
+    private final int unlockLevel;
+    private final int expReward;
+    private final boolean purchasable;
+
+    public static ShopItemResponse of(Item item, long currentCount, boolean purchasable) {
+        return new ShopItemResponse(
+                item.getId(),
+                item.getName(),
+                item.getPrice(),
+                item.getMaxCount(),
+                currentCount,
+                item.getUnlockLevel(),
+                item.getExpReward(),
+                purchasable
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -1,0 +1,43 @@
+package store.sonyk9919.api.domain.shop.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.service.ItemCache;
+import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopService {
+
+    private final ItemCache itemCache;
+    private final IslandItemUsageRepository islandItemUsageRepository;
+    private final MemberIslandRegistryService memberIslandRegistryService;
+
+    public List<ShopItemResponse> getItems(Long memberId) {
+        MemberIsland island = memberIslandRegistryService.getIsland(memberId);
+
+        Map<Long, Long> usageByItemId = islandItemUsageRepository.findAllByIsland(island).stream()
+                .collect(Collectors.toMap(u -> u.getItem().getId(), IslandItemUsage::getUseCount));
+
+        List<Item> items = itemCache.getAll();
+
+        return items.stream()
+                .map(item -> {
+                    long currentCount = usageByItemId.getOrDefault(item.getId(), 0L);
+                    boolean purchasable = island.getLevel() >= item.getUnlockLevel()
+                            && currentCount < item.getMaxCount();
+                    return ShopItemResponse.of(item, currentCount, purchasable);
+                })
+                .toList();
+    }
+}

--- a/src/main/resources/db/item.sql
+++ b/src/main/resources/db/item.sql
@@ -1,5 +1,5 @@
 insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (소)', 100, 2, 3, 250);
 insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (대)', 100, 4, 3, 250);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('토양 정화', 100, 8, 3, 125);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('수질 개선', 100, 10, 3, 125);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('나무 심기', 100, 20, 3, 75);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('토양 정화', 50, 8, 3, 125);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('수질 개선', 50, 10, 3, 125);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('나무 심기', 30, 20, 3, 75);

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -38,9 +38,9 @@ class ShopServiceTest {
         allItems = List.of(
                 createItem(1L, "쓰레기 제거 (소)", 100, 2, 3, 250),
                 createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
-                createItem(3L, "토양 정화",       100, 8, 3, 125),
-                createItem(4L, "수질 개선",       100, 10, 3, 125),
-                createItem(5L, "나무 심기",       100, 20, 3, 75)
+                createItem(3L, "토양 정화",       50, 8, 3, 125),
+                createItem(4L, "수질 개선",       50, 10, 3, 125),
+                createItem(5L, "나무 심기",       30, 20, 3, 75)
         );
         island = mock(MemberIsland.class);
         given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -1,0 +1,158 @@
+package store.sonyk9919.api.domain.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.service.ItemCache;
+import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+
+@ExtendWith(MockitoExtension.class)
+class ShopServiceTest {
+
+    @Mock private ItemCache itemCache;
+    @Mock private IslandItemUsageRepository islandItemUsageRepository;
+    @Mock private MemberIslandRegistryService memberIslandRegistryService;
+    @InjectMocks private ShopService shopService;
+
+    private static final Long MEMBER_ID = 1L;
+    private List<Item> allItems;
+    private MemberIsland island;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        allItems = List.of(
+                createItem(1L, "쓰레기 제거 (소)", 100, 2, 3, 250),
+                createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
+                createItem(3L, "토양 정화",       100, 8, 3, 125),
+                createItem(4L, "수질 개선",       100, 10, 3, 125),
+                createItem(5L, "나무 심기",       100, 20, 3, 75)
+        );
+        island = mock(MemberIsland.class);
+        given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
+        given(itemCache.getAll()).willReturn(allItems);
+    }
+
+    @Test
+    void getItems_아이템_5개를_반환한다() {
+        given(island.getLevel()).willReturn(3);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        assertThat(result).hasSize(5);
+    }
+
+    @Test
+    void getItems_IslandItemUsage_미존재_시_currentCount가_0이다() {
+        given(island.getLevel()).willReturn(3);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        assertThat(result).allMatch(r -> r.getCurrentCount() == 0);
+    }
+
+    @Test
+    void getItems_IslandItemUsage_존재_시_currentCount가_반영된다() throws Exception {
+        given(island.getLevel()).willReturn(3);
+
+        Item targetItem = allItems.get(0);
+        IslandItemUsage usage = mockUsage(targetItem, 1L);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        ShopItemResponse response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.getCurrentCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void getItems_레벨_조건_미달_시_purchasable이_false다() {
+        given(island.getLevel()).willReturn(2);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        assertThat(result).allMatch(r -> !r.isPurchasable());
+    }
+
+    @Test
+    void getItems_레벨_충족_시_purchasable이_true다() {
+        given(island.getLevel()).willReturn(3);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        assertThat(result).allMatch(ShopItemResponse::isPurchasable);
+    }
+
+    @Test
+    void getItems_maxCount_도달_시_purchasable이_false다() throws Exception {
+        given(island.getLevel()).willReturn(3);
+
+        Item targetItem = allItems.get(0);
+        IslandItemUsage usage = mockUsage(targetItem, 2L);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        ShopItemResponse response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.isPurchasable()).isFalse();
+    }
+
+    @Test
+    void getItems_maxCount_미달_시_purchasable이_true다() throws Exception {
+        given(island.getLevel()).willReturn(3);
+
+        Item targetItem = allItems.get(0);
+        IslandItemUsage usage = mockUsage(targetItem, 1L);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
+
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        ShopItemResponse response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.isPurchasable()).isTrue();
+    }
+
+    private IslandItemUsage mockUsage(Item item, long useCount) {
+        IslandItemUsage usage = mock(IslandItemUsage.class);
+        given(usage.getItem()).willReturn(item);
+        given(usage.getUseCount()).willReturn(useCount);
+        return usage;
+    }
+
+    private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
+            throws Exception {
+        Constructor<Item> ctor = Item.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Item item = ctor.newInstance();
+        ReflectionTestUtils.setField(item, "id", id);
+        ReflectionTestUtils.setField(item, "name", name);
+        ReflectionTestUtils.setField(item, "price", price);
+        ReflectionTestUtils.setField(item, "maxCount", maxCount);
+        ReflectionTestUtils.setField(item, "unlockLevel", unlockLevel);
+        ReflectionTestUtils.setField(item, "expReward", expReward);
+        return item;
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -47,6 +47,20 @@ class ShopServiceTest {
         given(itemCache.getAll()).willReturn(allItems);
     }
 
+    private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
+            throws Exception {
+        Constructor<Item> ctor = Item.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Item item = ctor.newInstance();
+        ReflectionTestUtils.setField(item, "id", id);
+        ReflectionTestUtils.setField(item, "name", name);
+        ReflectionTestUtils.setField(item, "price", price);
+        ReflectionTestUtils.setField(item, "maxCount", maxCount);
+        ReflectionTestUtils.setField(item, "unlockLevel", unlockLevel);
+        ReflectionTestUtils.setField(item, "expReward", expReward);
+        return item;
+    }
+
     @Test
     void getItems_아이템_5개를_반환한다() {
         given(island.getLevel()).willReturn(3);
@@ -140,19 +154,5 @@ class ShopServiceTest {
         given(usage.getItem()).willReturn(item);
         given(usage.getUseCount()).willReturn(useCount);
         return usage;
-    }
-
-    private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
-            throws Exception {
-        Constructor<Item> ctor = Item.class.getDeclaredConstructor();
-        ctor.setAccessible(true);
-        Item item = ctor.newInstance();
-        ReflectionTestUtils.setField(item, "id", id);
-        ReflectionTestUtils.setField(item, "name", name);
-        ReflectionTestUtils.setField(item, "price", price);
-        ReflectionTestUtils.setField(item, "maxCount", maxCount);
-        ReflectionTestUtils.setField(item, "unlockLevel", unlockLevel);
-        ReflectionTestUtils.setField(item, "expReward", expReward);
-        return item;
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 상점 도메인 신규 생성 및 아이템 목록 조회 API 추가 (`GET /v1/shops/items`)

### Feature

- `ItemRepository`, `IslandItemUsageRepository` 추가 (island 도메인)
- `ItemCache` 추가: 아이템 목록 Redis 캐싱 (`cacheNames = "items", key = "'all'"`)
- `GET /v1/shops/items`: 상점 아이템 목록 조회 API (shop 도메인 신규 생성)

### Test

- `ShopServiceTest` 추가: 아이템 반환 수, `currentCount`, `purchasable` 조건 검증 (7개 케이스)

## 상세 설명

- **shop 도메인 신규 생성**: island 도메인은 섬 관리(레벨, 자원 등)에 집중하고, 상점 비즈니스 로직은 shop 도메인으로 분리했습니다.
- **응답 필드**:
   - `currentCount`:  사용자가 해당 아이템을 구매(사용)한 횟수 (`IslandItemUsage.useCount`)
   - `purchasable`: 구매 가능 여부 (`island.level >= unlockLevel && currentCount < maxCount`)
- **캐싱**: 아이템 목록은 정적 데이터이므로 ItemCache를 통해 Redis 캐싱을 적용해보았습니다. `ShopService`는 `ItemRepository`를 직접 호출하지 않고 `ItemCache` 경유함
- **비즈니스 로직 위치**: `purchasable` 판단 조건은 DTO가 아닌 서비스 레이어(ShopService)에서 처리합니다.

## 체크리스트

- [x] GET /v1/shops/items 호출 시 아이템 5개 정상 반환
- [x] IslandItemUsage 미존재 시 currentCount = 0 으로 반환
- [x] purchasable 필드가 레벨 조건 및 maxCount 초과 여부에 맞게 계산
- [x] 동일 요청 반복 시 Redis 캐시 적중 (Redis CLI 통해 `items::all` 키 확인)

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-432

## 참고사항
- 아이템 구매 기능 (POST /v1/shops/items/{itemId}/purchase)은 후속 PR에서 구현 예정입니다!! (신속한 리뷰를 위해 PR 단위를 작게 분리하고자 했습니다,,)
- 보석 → 기프티콘 교환 기능도 이후 shop 도메인 내에 추가 예정입니다.
- 아이템마다 경험치 획득량이 다른데, [소모하는 조개 수가 같으면 밸런싱이 안 맞을 것 같다는 피드백](https://github.com/sudal-kgu/server/pull/40#discussion_r3057981729)을 받았어서 반영해봤습니다!!