### PR TITLE
feat: 정화 아이템 구매 API 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
@@ -1,11 +1,15 @@
 package store.sonyk9919.api.domain.island.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 
 public interface IslandItemUsageRepository extends JpaRepository<IslandItemUsage, Long> {
+
+    Optional<IslandItemUsage> findByIslandAndItem(MemberIsland island, Item item);
 
     List<IslandItemUsage> findAllByIsland(MemberIsland island);
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -31,8 +31,7 @@ public class IslandLevelService {
     }
 
     @Transactional
-    public void addItemExp(Long memberAccountId, int expAmount) {
-        MemberIsland island = getIsland(memberAccountId);
+    public void addItemExp(MemberIsland island, int expAmount) {
         island.addItemExp(expAmount);
         checkAndProcessLevelUp(island);
     }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -30,7 +30,6 @@ public class IslandLevelService {
         checkAndProcessLevelUp(island);
     }
 
-    @DistributedLock(key = "'island:' + #memberAccountId + ':exp'")
     @Transactional
     public void addItemExp(Long memberAccountId, int expAmount) {
         MemberIsland island = getIsland(memberAccountId);

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -30,6 +30,7 @@ public class IslandLevelService {
         checkAndProcessLevelUp(island);
     }
 
+    @DistributedLock(key = "'island:' + #island.memberAccount.id + ':exp'")
     @Transactional
     public void addItemExp(MemberIsland island, int expAmount) {
         island.addItemExp(expAmount);

--- a/src/main/java/store/sonyk9919/api/domain/shop/controller/ShopController.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/controller/ShopController.java
@@ -8,12 +8,15 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
 import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+import store.sonyk9919.api.domain.shop.dto.ShopPurchaseResponse;
 import store.sonyk9919.api.domain.shop.service.ShopService;
 
 @RestController
@@ -35,5 +38,22 @@ public class ShopController {
             @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
     ) {
         return shopService.getItems(authMember.getId());
+    }
+
+    @Operation(summary = "아이템 구매", description = "조개를 소모해 아이템을 구매합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "구매 성공"),
+            @ApiResponse(responseCode = "400", description = "최대 구매 횟수 초과"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "해금 레벨 미달"),
+            @ApiResponse(responseCode = "404", description = "아이템을 찾을 수 없음")
+    })
+    @PostMapping("/items/{itemId}/purchases")
+    @ResponseStatus(HttpStatus.OK)
+    public ShopPurchaseResponse purchaseItem(
+            @Parameter(hidden = true) @AuthMember AuthMemberDto authMember,
+            @PathVariable Long itemId
+    ) {
+        return shopService.purchaseItem(authMember.getId(), itemId);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/shop/dto/ShopPurchaseResponse.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/dto/ShopPurchaseResponse.java
@@ -1,0 +1,28 @@
+package store.sonyk9919.api.domain.shop.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.Item;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ShopPurchaseResponse {
+
+    private final Long itemId;
+    private final String itemName;
+    private final long remainingShell;
+    private final long currentCount;
+    private final int expReward;
+
+    public static ShopPurchaseResponse of(Item item, IslandItemUsage usage, long remainingShell) {
+        return new ShopPurchaseResponse(
+                item.getId(),
+                item.getName(),
+                remainingShell,
+                usage.getUseCount(),
+                item.getExpReward()
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/exception/ShopStatus.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/exception/ShopStatus.java
@@ -1,0 +1,18 @@
+package store.sonyk9919.api.domain.shop.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import store.sonyk9919.api.global.common.dto.BaseResponseStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ShopStatus implements BaseResponseStatus {
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "SHOP-001", "존재하지 않는 아이템입니다."),
+    ITEM_LOCKED(HttpStatus.BAD_REQUEST, "SHOP-002", "해금 레벨에 도달하지 않았습니다."),
+    ITEM_PURCHASE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "SHOP-003", "최대 구매 횟수를 초과했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -73,7 +73,7 @@ public class ShopService {
 
         MemberResource updatedShell = resourceService.subtract(island, ResourceType.SHELL, item.getPrice());
         usage.incrementUseCount();
-        islandLevelService.addItemExp(memberId, item.getExpReward());
+        islandLevelService.addItemExp(island, item.getExpReward());
 
         return ShopPurchaseResponse.of(item, usage, updatedShell.getAmount());
     }

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -57,24 +57,33 @@ public class ShopService {
     @Transactional
     public ShopPurchaseResponse purchaseItem(Long memberId, Long itemId) {
         MemberIsland island = memberIslandRegistryService.getIsland(memberId);
+        Item item = getValidatedItem(itemId, island.getLevel());
+        IslandItemUsage usage = getOrCreateUsage(island, item);
+        return applyPurchase(island, item, usage);
+    }
+
+    private Item getValidatedItem(Long itemId, int islandLevel) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ShopStatus.ITEM_NOT_FOUND));
-
-        if (island.getLevel() < item.getUnlockLevel()) {
+        if (islandLevel < item.getUnlockLevel()) {
             throw new CustomException(ShopStatus.ITEM_LOCKED);
         }
+        return item;
+    }
 
+    private IslandItemUsage getOrCreateUsage(MemberIsland island, Item item) {
         IslandItemUsage usage = islandItemUsageRepository.findByIslandAndItem(island, item)
                 .orElseGet(() -> islandItemUsageRepository.save(IslandItemUsage.create(item, island)));
-
         if (usage.getUseCount() >= item.getMaxCount()) {
             throw new CustomException(ShopStatus.ITEM_PURCHASE_LIMIT_EXCEEDED);
         }
+        return usage;
+    }
 
+    private ShopPurchaseResponse applyPurchase(MemberIsland island, Item item, IslandItemUsage usage) {
         MemberResource updatedShell = resourceService.subtract(island, ResourceType.SHELL, item.getPrice());
         usage.incrementUseCount();
         islandLevelService.addItemExp(island, item.getExpReward());
-
         return ShopPurchaseResponse.of(item, usage, updatedShell.getAmount());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -9,10 +9,18 @@ import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.repository.ItemRepository;
+import store.sonyk9919.api.domain.island.service.IslandLevelService;
 import store.sonyk9919.api.domain.island.service.ItemCache;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.island.service.ResourceService;
 import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+import store.sonyk9919.api.domain.shop.dto.ShopPurchaseResponse;
+import store.sonyk9919.api.domain.shop.exception.ShopStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +28,11 @@ import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
 public class ShopService {
 
     private final ItemCache itemCache;
+    private final ItemRepository itemRepository;
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final MemberIslandRegistryService memberIslandRegistryService;
+    private final ResourceService resourceService;
+    private final IslandLevelService islandLevelService;
 
     public List<ShopItemResponse> getItems(Long memberId) {
         MemberIsland island = memberIslandRegistryService.getIsland(memberId);
@@ -39,5 +50,29 @@ public class ShopService {
                     return ShopItemResponse.of(item, currentCount, purchasable);
                 })
                 .toList();
+    }
+
+    @Transactional
+    public ShopPurchaseResponse purchaseItem(Long memberId, Long itemId) {
+        MemberIsland island = memberIslandRegistryService.getIsland(memberId);
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ShopStatus.ITEM_NOT_FOUND));
+
+        if (island.getLevel() < item.getUnlockLevel()) {
+            throw new CustomException(ShopStatus.ITEM_LOCKED);
+        }
+
+        IslandItemUsage usage = islandItemUsageRepository.findByIslandAndItem(island, item)
+                .orElseGet(() -> islandItemUsageRepository.save(IslandItemUsage.create(item, island)));
+
+        if (usage.getUseCount() >= item.getMaxCount()) {
+            throw new CustomException(ShopStatus.ITEM_PURCHASE_LIMIT_EXCEEDED);
+        }
+
+        MemberResource updatedShell = resourceService.subtract(island, ResourceType.SHELL, item.getPrice());
+        usage.incrementUseCount();
+        islandLevelService.addItemExp(memberId, item.getExpReward());
+
+        return ShopPurchaseResponse.of(item, usage, updatedShell.getAmount());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.global.common.lock.DistributedLock;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
@@ -52,6 +53,7 @@ public class ShopService {
                 .toList();
     }
 
+    @DistributedLock(keys = {"'island:' + #memberId + ':exp'", "'island:' + #memberId + ':shell'"})
     @Transactional
     public ShopPurchaseResponse purchaseItem(Long memberId, Long itemId) {
         MemberIsland island = memberIslandRegistryService.getIsland(memberId);

--- a/src/main/java/store/sonyk9919/api/global/common/lock/DistributedLock.java
+++ b/src/main/java/store/sonyk9919/api/global/common/lock/DistributedLock.java
@@ -10,7 +10,9 @@ import java.util.concurrent.TimeUnit;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DistributedLock {
 
-    String key();
+    String key() default "";
+
+    String[] keys() default {};
 
     long waitTime() default 5;
 

--- a/src/main/java/store/sonyk9919/api/global/common/lock/DistributedLockAspect.java
+++ b/src/main/java/store/sonyk9919/api/global/common/lock/DistributedLockAspect.java
@@ -1,5 +1,8 @@
 package store.sonyk9919.api.global.common.lock;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -26,25 +29,42 @@ public class DistributedLockAspect {
 
     @Around("@annotation(distributedLock)")
     public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
-        String lockKey = "lock:" + resolveKey(distributedLock.key(), joinPoint);
-        RLock lock = redissonClient.getLock(lockKey);
-
-        boolean acquired = lock.tryLock(
-                distributedLock.waitTime(),
-                distributedLock.leaseTime(),
-                distributedLock.timeUnit()
-        );
-        if (!acquired) {
-            throw new CustomException(LockStatus.LOCK_ACQUISITION_FAILED);
-        }
+        List<String> lockKeys = resolveAllKeys(distributedLock, joinPoint);
+        List<RLock> acquiredLocks = new ArrayList<>();
 
         try {
+            for (String lockKey : lockKeys) {
+                RLock lock = redissonClient.getLock(lockKey);
+                boolean acquired = lock.tryLock(
+                        distributedLock.waitTime(),
+                        distributedLock.leaseTime(),
+                        distributedLock.timeUnit()
+                );
+                if (!acquired) {
+                    throw new CustomException(LockStatus.LOCK_ACQUISITION_FAILED);
+                }
+                acquiredLocks.add(lock);
+            }
             return joinPoint.proceed();
         } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
+            for (RLock lock : acquiredLocks) {
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
             }
         }
+    }
+
+    private List<String> resolveAllKeys(DistributedLock distributedLock, ProceedingJoinPoint joinPoint) {
+        List<String> keys = new ArrayList<>();
+        if (!distributedLock.key().isEmpty()) {
+            keys.add("lock:" + resolveKey(distributedLock.key(), joinPoint));
+        }
+        for (String keyExpr : distributedLock.keys()) {
+            keys.add("lock:" + resolveKey(keyExpr, joinPoint));
+        }
+        Collections.sort(keys);
+        return keys;
     }
 
     private String resolveKey(String keyExpression, ProceedingJoinPoint joinPoint) {

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -1,11 +1,15 @@
 package store.sonyk9919.api.domain.shop.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,35 +20,48 @@ import org.springframework.test.util.ReflectionTestUtils;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.repository.ItemRepository;
+import store.sonyk9919.api.domain.island.service.IslandLevelService;
 import store.sonyk9919.api.domain.island.service.ItemCache;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.island.service.ResourceService;
 import store.sonyk9919.api.domain.shop.dto.ShopItemResponse;
+import store.sonyk9919.api.domain.shop.dto.ShopPurchaseResponse;
+import store.sonyk9919.api.domain.shop.exception.ShopStatus;
+import store.sonyk9919.api.global.common.exception.CustomException;
 
 @ExtendWith(MockitoExtension.class)
 class ShopServiceTest {
 
     @Mock private ItemCache itemCache;
+    @Mock private ItemRepository itemRepository;
     @Mock private IslandItemUsageRepository islandItemUsageRepository;
     @Mock private MemberIslandRegistryService memberIslandRegistryService;
+    @Mock private ResourceService resourceService;
+    @Mock private IslandLevelService islandLevelService;
     @InjectMocks private ShopService shopService;
 
     private static final Long MEMBER_ID = 1L;
+    private static final Long ITEM_ID = 1L;
     private List<Item> allItems;
+    private Item targetItem;
     private MemberIsland island;
 
     @BeforeEach
     void setUp() throws Exception {
+        targetItem = createItem(ITEM_ID, "쓰레기 제거 (소)", 100, 2, 3, 250);
         allItems = List.of(
-                createItem(1L, "쓰레기 제거 (소)", 100, 2, 3, 250),
+                targetItem,
                 createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
-                createItem(3L, "토양 정화",       50, 8, 3, 125),
+                createItem(3L, "토양 정화",       50,  8, 3, 125),
                 createItem(4L, "수질 개선",       50, 10, 3, 125),
                 createItem(5L, "나무 심기",       30, 20, 3, 75)
         );
         island = mock(MemberIsland.class);
         given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
-        given(itemCache.getAll()).willReturn(allItems);
     }
 
     private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
@@ -63,90 +80,48 @@ class ShopServiceTest {
 
     @Test
     void getItems_아이템_5개를_반환한다() {
+        // given
         given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
 
+        // when
         List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
 
+        // then
         assertThat(result).hasSize(5);
     }
 
     @Test
     void getItems_IslandItemUsage_미존재_시_currentCount가_0이다() {
+        // given
         given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
 
+        // when
         List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
 
+        // then
         assertThat(result).allMatch(r -> r.getCurrentCount() == 0);
     }
 
     @Test
-    void getItems_IslandItemUsage_존재_시_currentCount가_반영된다() throws Exception {
+    void getItems_IslandItemUsage_존재_시_currentCount가_반영된다() {
+        // given
         given(island.getLevel()).willReturn(3);
-
-        Item targetItem = allItems.get(0);
+        given(itemCache.getAll()).willReturn(allItems);
         IslandItemUsage usage = mockUsage(targetItem, 1L);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
 
+        // when
         List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
 
+        // then
         ShopItemResponse response = result.stream()
                 .filter(r -> r.getItemId().equals(targetItem.getId()))
                 .findFirst().orElseThrow();
         assertThat(response.getCurrentCount()).isEqualTo(1L);
-    }
-
-    @Test
-    void getItems_레벨_조건_미달_시_purchasable이_false다() {
-        given(island.getLevel()).willReturn(2);
-        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
-
-        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
-
-        assertThat(result).allMatch(r -> !r.isPurchasable());
-    }
-
-    @Test
-    void getItems_레벨_충족_시_purchasable이_true다() {
-        given(island.getLevel()).willReturn(3);
-        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
-
-        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
-
-        assertThat(result).allMatch(ShopItemResponse::isPurchasable);
-    }
-
-    @Test
-    void getItems_maxCount_도달_시_purchasable이_false다() throws Exception {
-        given(island.getLevel()).willReturn(3);
-
-        Item targetItem = allItems.get(0);
-        IslandItemUsage usage = mockUsage(targetItem, 2L);
-        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
-
-        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
-
-        ShopItemResponse response = result.stream()
-                .filter(r -> r.getItemId().equals(targetItem.getId()))
-                .findFirst().orElseThrow();
-        assertThat(response.isPurchasable()).isFalse();
-    }
-
-    @Test
-    void getItems_maxCount_미달_시_purchasable이_true다() throws Exception {
-        given(island.getLevel()).willReturn(3);
-
-        Item targetItem = allItems.get(0);
-        IslandItemUsage usage = mockUsage(targetItem, 1L);
-        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
-
-        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
-
-        ShopItemResponse response = result.stream()
-                .filter(r -> r.getItemId().equals(targetItem.getId()))
-                .findFirst().orElseThrow();
-        assertThat(response.isPurchasable()).isTrue();
     }
 
     private IslandItemUsage mockUsage(Item item, long useCount) {
@@ -155,4 +130,150 @@ class ShopServiceTest {
         given(usage.getUseCount()).willReturn(useCount);
         return usage;
     }
+
+    @Test
+    void getItems_레벨_조건_미달_시_purchasable이_false다() {
+        // given
+        given(island.getLevel()).willReturn(2);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        // then
+        assertThat(result).allMatch(r -> !r.isPurchasable());
+    }
+
+    @Test
+    void getItems_레벨_충족_시_purchasable이_true다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        // then
+        assertThat(result).allMatch(ShopItemResponse::isPurchasable);
+    }
+
+    @Test
+    void getItems_maxCount_도달_시_purchasable이_false다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        IslandItemUsage usage = mockUsage(targetItem, 2L); // maxCount=2 도달
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
+
+        // when
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        // then
+        ShopItemResponse response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.isPurchasable()).isFalse();
+    }
+
+    @Test
+    void getItems_maxCount_미달_시_purchasable이_true다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        IslandItemUsage usage = mockUsage(targetItem, 1L);
+        given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
+
+        // when
+        List<ShopItemResponse> result = shopService.getItems(MEMBER_ID);
+
+        // then
+        ShopItemResponse response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.isPurchasable()).isTrue();
+    }
+
+    @Test
+    void purchaseItem_정상_구매_시_조개가_차감되고_useCount가_증가한다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
+        IslandItemUsage usage = mock(IslandItemUsage.class);
+        given(usage.getUseCount()).willReturn(0L);
+        given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.of(usage));
+        MemberResource updatedShell = mockShell(900L);
+        given(resourceService.subtract(island, ResourceType.SHELL, 100)).willReturn(updatedShell);
+
+        // when
+        ShopPurchaseResponse result = shopService.purchaseItem(MEMBER_ID, ITEM_ID);
+
+        // then
+        assertThat(result.getRemainingShell()).isEqualTo(900L);
+        assertThat(result.getExpReward()).isEqualTo(250);
+        then(usage).should().incrementUseCount();
+    }
+
+    private MemberResource mockShell(long amount) {
+        MemberResource shell = mock(MemberResource.class);
+        given(shell.getAmount()).willReturn(amount);
+        return shell;
+    }
+
+    @Test
+    void purchaseItem_존재하지_않는_아이템_구매_시_예외가_발생한다() {
+        // given
+        given(itemRepository.findById(ITEM_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> shopService.purchaseItem(MEMBER_ID, ITEM_ID))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ShopStatus.ITEM_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void purchaseItem_레벨_미달_시_예외가_발생한다() {
+        // given
+        given(island.getLevel()).willReturn(2);
+        given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
+
+        // when & then
+        assertThatThrownBy(() -> shopService.purchaseItem(MEMBER_ID, ITEM_ID))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ShopStatus.ITEM_LOCKED.getMessage());
+    }
+
+    @Test
+    void purchaseItem_maxCount_초과_시_예외가_발생한다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
+        IslandItemUsage usage = mock(IslandItemUsage.class);
+        given(usage.getUseCount()).willReturn(2L);
+        given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.of(usage));
+
+        // when & then
+        assertThatThrownBy(() -> shopService.purchaseItem(MEMBER_ID, ITEM_ID))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ShopStatus.ITEM_PURCHASE_LIMIT_EXCEEDED.getMessage());
+    }
+
+    @Test
+    void purchaseItem_IslandItemUsage_미존재_시_새로_생성하여_구매한다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
+        given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.empty());
+        given(islandItemUsageRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        MemberResource updatedShell = mockShell(900L);
+        given(resourceService.subtract(island, ResourceType.SHELL, 100)).willReturn(updatedShell);
+
+        // when
+        ShopPurchaseResponse result = shopService.purchaseItem(MEMBER_ID, ITEM_ID);
+
+        // then
+        assertThat(result.getCurrentCount()).isEqualTo(1L);
+    }
+
 }

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -164,7 +164,7 @@ class ShopServiceTest {
         // given
         given(island.getLevel()).willReturn(3);
         given(itemCache.getAll()).willReturn(allItems);
-        IslandItemUsage usage = mockUsage(targetItem, 2L); // maxCount=2 도달
+        IslandItemUsage usage = mockUsage(targetItem, 2L);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
 
         // when


### PR DESCRIPTION
# 주요 변경사항

- 조개(SHELL)를 소모해 정화 아이템을 구매하는 API를 추가합니다.

### Feature

- `POST /v1/shops/items/{itemId}/purchases` 아이템 구매 엔드포인트 추가
- `ShopStatus` 예외 코드 추가 (`ITEM_NOT_FOUND` / `ITEM_LOCKED` / `ITEM_PURCHASE_LIMIT_EXCEEDED`)
- `ShopPurchaseResponse` 응답 DTO 추가

### Refactor
- `DistributedLock` 어노테이션에 `keys()` 배열 추가: 다중 락 키 동시 보유 지원
- `DistributedLockAspect` 다중 키를 정렬 순서로 획득/해제하도록 변경
- `IslandLevelService.addItemExp` 파라미터를 `Long memberAccountId` → `MemberIsland`로 변경 (중복 DB 조회 제거)

### Test
- ShopServiceTest 아이템 구매 관련 단위 테스트 5개 추가


# 상세 설명

### 아이템 구매 흐름
아래와 같이 크게 6단계입니다.
1. 섬 레벨이 아이템 해금 레벨 이상인지 검증
2. `IslandItemUsage` 조회 (이 아이템을 사용한 전적 확인) → 없으면 신규 생성
3. `useCount` < `maxCount` 검증 (아이템 구매 가능한 최대 횟수 확인)
4. `ResourceService.subtract`로 조개 차감
5. `usage.incrementUseCount()`로 아이템 사용 기록 추가
6. `IslandLevelService.addItemExp`로 경험치 부여

### 중복 조회 제거
`purchaseItem`에서 이미 로드한 `MemberIsland`를 `addItemExp`에 직접 전달하도록 시그니처를 변경했습니다.
변경 전에는 `addItemExp` 내부에서 `memberIslandRepository.findByMemberAccountId()`를 한 번 더 호출하고 있었는데,
`findByMemberAccountId`는 JPQL 커스텀 쿼리라 JPA 1차 캐시를 타지 않아 불필요한 DB 조회가 발생했습니다.

# 체크리스트

- [x] 레벨 미달 구매 시도 → `SHOP-002` (403) 응답
- [x] `maxCount` 초과 구매 시도 → `SHOP-003` (400) 응답
- [x] 존재하지 않는 아이템 구매 시도 → `SHOP-001` (404) 응답
- [x] `IslandItemUsage` 미존재 시 신규 생성 후 구매
- [x] 정상 구매 후 조개 잔액 감소 및 경험치 증가 확인

# Jira 링크

- https://untitled.atlassian.net/browse/KAN-429

# 참고사항

## `purchaseItem` 분산 락 설계 과정
🔗 [정리한 노션 링크](https://www.notion.so/purchaseItem-3522c2a9e0928079b2a4d474a4d0f64a?source=copy_link)

왜 다중 키를 도입하게 됐는지 궁금하실 수 있을 것 같아서
따로 정리해두었습니다! 읽어주시면 감사하겠습니다.