### PR TITLE
feat: 분리배출 인증 사이클 완료 시 보상 지급 기능 구현

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/entity/LevelSpec.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/LevelSpec.java
@@ -26,4 +26,7 @@ public class LevelSpec {
 
     @Column(nullable = false)
     private int expPerRecycling;
+
+    @Column(nullable = false)
+    private int fuelPerRecycling;
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -7,9 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.event.IslandLevelUpEvent;
-import store.sonyk9919.api.domain.island.exception.IslandStatus;
-import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
-import store.sonyk9919.api.global.common.exception.CustomException;
 import store.sonyk9919.api.global.common.lock.DistributedLock;
 
 @Service
@@ -17,14 +14,12 @@ import store.sonyk9919.api.global.common.lock.DistributedLock;
 @Transactional(readOnly = true)
 public class IslandLevelService {
 
-    private final MemberIslandRepository memberIslandRepository;
     private final LevelSpecCache levelSpecCache;
     private final ApplicationEventPublisher eventPublisher;
 
-    @DistributedLock(key = "'island:' + #memberAccountId + ':exp'")
+    @DistributedLock(key = "'island:' + #island.memberAccount.id + ':exp'")
     @Transactional
-    public void addRecyclingExp(Long memberAccountId) {
-        MemberIsland island = getIsland(memberAccountId);
+    public void addRecyclingExp(MemberIsland island) {
         LevelSpec currentSpec = getLevelSpec(island.getLevel());
         island.addRecyclingExp(currentSpec);
         checkAndProcessLevelUp(island);
@@ -51,11 +46,6 @@ public class IslandLevelService {
                 previousLevel,
                 island.getLevel()
         ));
-    }
-
-    private MemberIsland getIsland(Long memberAccountId) {
-        return memberIslandRepository.findByMemberAccountId(memberAccountId)
-                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
     }
 
     private LevelSpec getLevelSpec(int level) {

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -7,6 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.event.IslandLevelUpEvent;
+import store.sonyk9919.api.domain.island.exception.IslandStatus;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
 import store.sonyk9919.api.global.common.lock.DistributedLock;
 
 @Service
@@ -16,18 +19,23 @@ public class IslandLevelService {
 
     private final LevelSpecCache levelSpecCache;
     private final ApplicationEventPublisher eventPublisher;
+    private final MemberIslandRepository memberIslandRepository;
 
-    @DistributedLock(key = "'island:' + #island.memberAccount.id + ':exp'")
+    @DistributedLock(key = "'island:' + #memberAccountId + ':exp'")
     @Transactional
-    public void addRecyclingExp(MemberIsland island) {
+    public void addRecyclingExp(Long memberAccountId) {
+        MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
+                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
         LevelSpec currentSpec = getLevelSpec(island.getLevel());
         island.addRecyclingExp(currentSpec);
         checkAndProcessLevelUp(island);
     }
 
-    @DistributedLock(key = "'island:' + #island.memberAccount.id + ':exp'")
+    @DistributedLock(key = "'island:' + #memberAccountId + ':exp'")
     @Transactional
-    public void addItemExp(MemberIsland island, int expAmount) {
+    public void addItemExp(Long memberAccountId, int expAmount) {
+        MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
+                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
         island.addItemExp(expAmount);
         checkAndProcessLevelUp(island);
     }

--- a/src/main/java/store/sonyk9919/api/domain/quiz/controller/QuizController.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/controller/QuizController.java
@@ -13,6 +13,7 @@ import store.sonyk9919.api.domain.quiz.dto.QuizChoiceRequestDto;
 import store.sonyk9919.api.domain.quiz.dto.QuizCreateRequestDto;
 import store.sonyk9919.api.domain.quiz.dto.QuizProblemResponseDto;
 import store.sonyk9919.api.domain.quiz.dto.QuizSessionResponseDto;
+import store.sonyk9919.api.domain.quiz.dto.RecyclingRewardResponse;
 import store.sonyk9919.api.domain.quiz.service.QuizPlayService;
 
 import java.util.List;
@@ -81,14 +82,14 @@ public class QuizController {
         return quizPlayService.confirmQuizChoice(authMember.getId(), sessionId, problemId, request.getChoice());
     }
 
-    @Operation(summary = "퀴즈 세션 완료", description = "현재 진행 중인 퀴즈 세션을 강제로 만료(완료) 처리합니다.")
-    @ApiResponse(responseCode = "200", description = "세션 만료(완료) 성공")
+    @Operation(summary = "퀴즈 세션 완료", description = "현재 진행 중인 퀴즈 세션을 완료 처리하고 분리배출 보상(조개, 연료, 경험치)을 지급합니다.")
+    @ApiResponse(responseCode = "200", description = "세션 완료 및 보상 지급 성공")
     @PostMapping("/sessions/{sessionId}/complete")
     @ResponseStatus(HttpStatus.OK)
-    public void completeQuizSession(
+    public RecyclingRewardResponse completeQuizSession(
             @Parameter(hidden = true) @AuthMember AuthMemberDto authMember,
             @Parameter(description = "퀴즈 세션 ID", example = "1") @PathVariable Long sessionId
     ) {
-        quizPlayService.completeQuizSession(authMember.getId(), sessionId);
+        return quizPlayService.completeQuizSession(authMember.getId(), sessionId);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/quiz/dto/RecyclingRewardResponse.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/dto/RecyclingRewardResponse.java
@@ -1,0 +1,18 @@
+package store.sonyk9919.api.domain.quiz.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RecyclingRewardResponse {
+
+    private final int earnedShell;
+    private final int earnedFuel;
+    private final int earnedExp;
+
+    public static RecyclingRewardResponse of(int shell, int fuel, int exp) {
+        return new RecyclingRewardResponse(shell, fuel, exp);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
@@ -130,14 +130,14 @@ public class QuizPlayService {
     }
 
     private RecyclingRewardResponse grantRewards(MemberIsland island) {
-        final int fuelReward = 100;
-        int earnedExp = levelSpecCache.get(island.getLevel()).getExpPerRecycling();
         int earnedShell = rewardCalculator.calculateShell(island);
+        int earnedFuel = levelSpecCache.get(island.getLevel()).getFuelPerRecycling();
+        int earnedExp = levelSpecCache.get(island.getLevel()).getExpPerRecycling();
 
         resourceService.add(island, ResourceType.SHELL, earnedShell);
-        resourceService.add(island, ResourceType.FUEL, fuelReward);
+        resourceService.add(island, ResourceType.FUEL, earnedFuel);
         islandLevelService.addRecyclingExp(island);
 
-        return RecyclingRewardResponse.of(earnedShell, fuelReward, earnedExp);
+        return RecyclingRewardResponse.of(earnedShell, earnedFuel, earnedExp);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
@@ -126,17 +126,17 @@ public class QuizPlayService {
         }
         MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
         session.expireSession();
-        return grantRewards(island);
+        return grantRewards(memberAccountId, island);
     }
 
-    private RecyclingRewardResponse grantRewards(MemberIsland island) {
+    private RecyclingRewardResponse grantRewards(Long memberAccountId, MemberIsland island) {
         int earnedShell = rewardCalculator.calculateShell(island);
         int earnedFuel = levelSpecCache.get(island.getLevel()).getFuelPerRecycling();
         int earnedExp = levelSpecCache.get(island.getLevel()).getExpPerRecycling();
 
         resourceService.add(island, ResourceType.SHELL, earnedShell);
         resourceService.add(island, ResourceType.FUEL, earnedFuel);
-        islandLevelService.addRecyclingExp(island);
+        islandLevelService.addRecyclingExp(memberAccountId);
 
         return RecyclingRewardResponse.of(earnedShell, earnedFuel, earnedExp);
     }

--- a/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/service/QuizPlayService.java
@@ -4,9 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+import store.sonyk9919.api.domain.island.service.IslandLevelService;
+import store.sonyk9919.api.domain.island.service.LevelSpecCache;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.island.service.ResourceService;
 import store.sonyk9919.api.domain.quiz.dto.QuizSessionResponseDto;
 import store.sonyk9919.api.domain.quiz.dto.QuizProblemResponseDto;
+import store.sonyk9919.api.domain.quiz.dto.RecyclingRewardResponse;
 import store.sonyk9919.api.domain.quiz.entity.Quiz;
 import store.sonyk9919.api.domain.quiz.entity.QuizSession;
 import store.sonyk9919.api.domain.quiz.entity.QuizSessionProblem;
@@ -28,6 +33,10 @@ public class QuizPlayService {
     private final QuizSessionProblemRegistryService quizSessionProblemRegistryService;
     private final TrashSearchService trashSearchService;
     private final MemberIslandRegistryService memberIslandRegistryService;
+    private final IslandLevelService islandLevelService;
+    private final ResourceService resourceService;
+    private final LevelSpecCache levelSpecCache;
+    private final RecyclingRewardCalculator rewardCalculator;
 
     @DistributedLock(key = "'quiz:' + #memberAccountId")
     @Transactional
@@ -106,12 +115,29 @@ public class QuizPlayService {
         return quizSessionProblemRegistryService.getProblem(memberAccountId, sessionId, problemId);
     }
 
+    @DistributedLock(keys = {"'island:' + #memberAccountId + ':exp'",
+                                "'island:' + #memberAccountId + ':shell'",
+                                "'island:' + #memberAccountId + ':fuel'"})
     @Transactional
-    public void completeQuizSession(Long memberAccountId, Long sessionId) {
+    public RecyclingRewardResponse completeQuizSession(Long memberAccountId, Long sessionId) {
         QuizSession session = quizSessionRegistryService.getSession(memberAccountId, sessionId);
         if (session.isExpired()) {
-            return;
+            throw new CustomException(QuizStatus.EXPIRED_QUIZ_SESSION);
         }
+        MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
         session.expireSession();
+        return grantRewards(island);
+    }
+
+    private RecyclingRewardResponse grantRewards(MemberIsland island) {
+        final int fuelReward = 100;
+        int earnedExp = levelSpecCache.get(island.getLevel()).getExpPerRecycling();
+        int earnedShell = rewardCalculator.calculateShell(island);
+
+        resourceService.add(island, ResourceType.SHELL, earnedShell);
+        resourceService.add(island, ResourceType.FUEL, fuelReward);
+        islandLevelService.addRecyclingExp(island);
+
+        return RecyclingRewardResponse.of(earnedShell, fuelReward, earnedExp);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/quiz/service/RecyclingRewardCalculator.java
+++ b/src/main/java/store/sonyk9919/api/domain/quiz/service/RecyclingRewardCalculator.java
@@ -1,0 +1,14 @@
+package store.sonyk9919.api.domain.quiz.service;
+
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+
+@Component
+public class RecyclingRewardCalculator {
+
+    private static final int BASE_SHELL = 10;
+
+    public int calculateShell(MemberIsland island) {
+        return BASE_SHELL;
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/ShopService.java
@@ -59,7 +59,7 @@ public class ShopService {
         MemberIsland island = memberIslandRegistryService.getIsland(memberId);
         Item item = getValidatedItem(itemId, island.getLevel());
         IslandItemUsage usage = getOrCreateUsage(island, item);
-        return applyPurchase(island, item, usage);
+        return applyPurchase(memberId, island, item, usage);
     }
 
     private Item getValidatedItem(Long itemId, int islandLevel) {
@@ -80,10 +80,10 @@ public class ShopService {
         return usage;
     }
 
-    private ShopPurchaseResponse applyPurchase(MemberIsland island, Item item, IslandItemUsage usage) {
+    private ShopPurchaseResponse applyPurchase(Long memberId, MemberIsland island, Item item, IslandItemUsage usage) {
         MemberResource updatedShell = resourceService.subtract(island, ResourceType.SHELL, item.getPrice());
         usage.incrementUseCount();
-        islandLevelService.addItemExp(island, item.getExpReward());
+        islandLevelService.addItemExp(memberId, item.getExpReward());
         return ShopPurchaseResponse.of(item, usage, updatedShell.getAmount());
     }
 }

--- a/src/main/resources/db/level_spec.sql
+++ b/src/main/resources/db/level_spec.sql
@@ -1,7 +1,7 @@
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (1, 500, 500, 2, 100);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (2, 1500, 1000, 3, 100);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (3, 3000, 1000, 4, 100);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (4, 4500, 500, 5, 50);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (5, 6250, 750, 6, 50);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (6, 8250, 1000, 7, 50);
-insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling) values (7, 11250, 1500, 7, 50);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (1, 500, 500, 2, 100, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (2, 1500, 1000, 3, 100, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (3, 3000, 1000, 4, 100, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (4, 4500, 500, 5, 50, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (5, 6250, 750, 6, 50, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (6, 8250, 1000, 7, 50, 100);
+insert into level_spec (level, required_exp, recycling_contribution_exp_limit, max_slot_count, exp_per_recycling, fuel_per_recycling) values (7, 11250, 1500, 7, 50, 100);

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
@@ -21,6 +21,9 @@ import store.sonyk9919.api.domain.auth.service.KakaoProvider;
 import store.sonyk9919.api.global.common.exception.CustomException;
 import store.sonyk9919.api.global.common.lock.LockStatus;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,6 +82,43 @@ class IslandLevelServiceConcurrencyTest {
     void tearDown() {
         jdbcTemplate.update("DELETE FROM member_island WHERE member_account_id = ?", memberAccountId);
         jdbcTemplate.update("DELETE FROM member_account WHERE member_account_id = ?", memberAccountId);
+    }
+
+    @Test
+    @DisplayName("동시에 3번 addRecyclingExp를 호출해도 exp가 정확히 300 쌓인다")
+    void addRecyclingExp_동시_3회_호출_시_exp가_정확히_300_쌓인다() throws InterruptedException {
+        // given
+        int threadCount = 3;
+        int expectedExp = 300;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    islandLevelService.addRecyclingExp(memberAccountId);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // then
+        Integer cumulativeExp = jdbcTemplate.queryForObject(
+                "SELECT cumulative_exp FROM member_island WHERE member_account_id = ?",
+                Integer.class, memberAccountId
+        );
+        assertThat(cumulativeExp).isEqualTo(expectedExp);
     }
 
     @Test

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,14 +13,15 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import store.sonyk9919.api.domain.auth.service.KakaoProvider;
+import store.sonyk9919.api.global.common.exception.CustomException;
+import store.sonyk9919.api.global.common.lock.LockStatus;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +49,15 @@ class IslandLevelServiceConcurrencyTest {
     private IslandLevelService islandLevelService;
 
     @Autowired
+    private MemberIslandRegistryService memberIslandRegistryService;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Autowired
     private JdbcTemplate jdbcTemplate;
 
     private Long memberAccountId;
@@ -60,7 +72,6 @@ class IslandLevelServiceConcurrencyTest {
                 "SELECT member_account_id FROM member_account WHERE provider_id = ?",
                 Long.class, "test-user-lock"
         );
-
         jdbcTemplate.update(
                 "INSERT INTO member_island (nickname, level, cumulative_exp, recycling_contribution_exp, item_contribution_exp, member_account_id) VALUES (?, ?, ?, ?, ?, ?)",
                 "테스트섬", 1, 0, 0, 0, memberAccountId
@@ -74,37 +85,33 @@ class IslandLevelServiceConcurrencyTest {
     }
 
     @Test
-    @DisplayName("동시에 3번 addRecyclingExp를 호출해도 exp가 정확히 300 쌓인다")
-    void concurrentAddRecyclingExp() throws InterruptedException {
-        int threadCount = 3;
-        int expectedExp = 300;
+    @DisplayName("addRecyclingExp 락이 이미 점유 중이면 두 번째 호출은 409를 반환한다")
+    void addRecyclingExp_락_점유_중_409_반환() throws InterruptedException {
+        RLock lock = redissonClient.getLock("lock:island:" + memberAccountId + ":exp");
+        lock.lock();
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread thread = new Thread(() -> {
+            try {
+                transactionTemplate.execute(status -> {
+                    islandLevelService.addRecyclingExp(
+                            memberIslandRegistryService.getIsland(memberAccountId)
+                    );
+                    return null;
+                });
+            } catch (Throwable e) {
+                thrown.set(e);
+            }
+        });
 
-        for (int i = 0; i < threadCount; i++) {
-            executor.submit(() -> {
-                try {
-                    startLatch.await();
-                    islandLevelService.addRecyclingExp(memberAccountId);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                } finally {
-                    doneLatch.countDown();
-                }
-            });
+        try {
+            thread.start();
+            thread.join();
+        } finally {
+            lock.unlock();
         }
 
-        startLatch.countDown();
-        doneLatch.await();
-        executor.shutdown();
-
-        Integer cumulativeExp = jdbcTemplate.queryForObject(
-                "SELECT cumulative_exp FROM member_island WHERE member_account_id = ?",
-                Integer.class, memberAccountId
-        );
-
-        assertThat(cumulativeExp).isEqualTo(expectedExp);
+        assertThat(thrown.get()).isInstanceOf(CustomException.class);
+        assertThat(((CustomException) thrown.get()).getStatus()).isEqualTo(LockStatus.LOCK_ACQUISITION_FAILED);
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceConcurrencyTest.java
@@ -49,9 +49,6 @@ class IslandLevelServiceConcurrencyTest {
     private IslandLevelService islandLevelService;
 
     @Autowired
-    private MemberIslandRegistryService memberIslandRegistryService;
-
-    @Autowired
     private RedissonClient redissonClient;
 
     @Autowired
@@ -94,9 +91,7 @@ class IslandLevelServiceConcurrencyTest {
         Thread thread = new Thread(() -> {
             try {
                 transactionTemplate.execute(status -> {
-                    islandLevelService.addRecyclingExp(
-                            memberIslandRegistryService.getIsland(memberAccountId)
-                    );
+                    islandLevelService.addRecyclingExp(memberAccountId);
                     return null;
                 });
             } catch (Throwable e) {

--- a/src/test/java/store/sonyk9919/api/domain/quiz/service/QuizPlayServiceConcurrencyTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/quiz/service/QuizPlayServiceConcurrencyTest.java
@@ -19,7 +19,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import store.sonyk9919.api.domain.auth.service.KakaoProvider;
-import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.service.IslandLevelService;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.shop.service.ShopService;
@@ -97,10 +96,9 @@ class QuizPlayServiceConcurrencyTest {
 
         itemId = jdbcTemplate.queryForObject("SELECT item_id FROM item LIMIT 1", Long.class);
 
-        MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
-        islandLevelService.addRecyclingExp(island);
+        islandLevelService.addRecyclingExp(memberAccountId);
 
-        sessionId = quizSessionRegistryService.create(island).getId();
+        sessionId = quizSessionRegistryService.create(memberIslandRegistryService.getIsland(memberAccountId)).getId();
     }
 
     @AfterEach

--- a/src/test/java/store/sonyk9919/api/domain/quiz/service/QuizPlayServiceConcurrencyTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/quiz/service/QuizPlayServiceConcurrencyTest.java
@@ -1,0 +1,169 @@
+package store.sonyk9919.api.domain.quiz.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import store.sonyk9919.api.domain.auth.service.KakaoProvider;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.service.IslandLevelService;
+import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+import store.sonyk9919.api.domain.shop.service.ShopService;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class QuizPlayServiceConcurrencyTest {
+
+    @Container
+    private static final GenericContainer<?> redis =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void setRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @MockitoBean
+    private ConnectionFactory connectionFactory;
+
+    @MockitoBean
+    private KakaoProvider kakaoProvider;
+
+    @Autowired
+    private QuizPlayService quizPlayService;
+
+    @Autowired
+    private QuizSessionRegistryService quizSessionRegistryService;
+
+    @Autowired
+    private MemberIslandRegistryService memberIslandRegistryService;
+
+    @Autowired
+    private IslandLevelService islandLevelService;
+
+    @Autowired
+    private ShopService shopService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Long memberAccountId;
+    private Long islandId;
+    private Long sessionId;
+    private Long itemId;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update(
+                "INSERT INTO member_account (account_role, provider_type, provider_id) VALUES (?, ?, ?)",
+                "USER", "KAKAO", "test-concurrent");
+        memberAccountId = jdbcTemplate.queryForObject(
+                "SELECT member_account_id FROM member_account WHERE provider_id = ?",
+                Long.class, "test-concurrent");
+
+        jdbcTemplate.update(
+                "INSERT INTO member_island (nickname, level, cumulative_exp, recycling_contribution_exp, item_contribution_exp, member_account_id) VALUES (?, ?, ?, ?, ?, ?)",
+                "테스트섬", 1, 0, 0, 0, memberAccountId);
+        islandId = jdbcTemplate.queryForObject(
+                "SELECT island_id FROM member_island WHERE member_account_id = ?",
+                Long.class, memberAccountId);
+
+        jdbcTemplate.update("INSERT INTO member_resource (resource_type, amount, island_id) VALUES ('SHELL', 0, ?)", islandId);
+        jdbcTemplate.update("INSERT INTO member_resource (resource_type, amount, island_id) VALUES ('FUEL', 0, ?)", islandId);
+
+        itemId = jdbcTemplate.queryForObject("SELECT item_id FROM item LIMIT 1", Long.class);
+
+        MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
+        islandLevelService.addRecyclingExp(island);
+
+        sessionId = quizSessionRegistryService.create(island).getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("DELETE FROM quiz_session WHERE island_id = ?", islandId);
+        jdbcTemplate.update("DELETE FROM member_resource WHERE island_id = ?", islandId);
+        jdbcTemplate.update("DELETE FROM member_island WHERE island_id = ?", islandId);
+        jdbcTemplate.update("DELETE FROM member_account WHERE member_account_id = ?", memberAccountId);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("동일 유저 동시 호출 시 보상이 정확히 1회만 지급된다")
+    void completeQuizSession_동시_호출_시_보상이_정확히_1회만_지급된다() throws InterruptedException {
+        // given
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        List<Exception> exceptions = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    quizPlayService.completeQuizSession(memberAccountId, sessionId);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        doneLatch.await();
+        executor.shutdown();
+
+        // then
+        Long shell = jdbcTemplate.queryForObject(
+                "SELECT amount FROM member_resource WHERE island_id = ? AND resource_type = 'SHELL'",
+                Long.class, islandId);
+        Long fuel = jdbcTemplate.queryForObject(
+                "SELECT amount FROM member_resource WHERE island_id = ? AND resource_type = 'FUEL'",
+                Long.class, islandId);
+
+        assertThat(shell).isEqualTo(10L);
+        assertThat(fuel).isEqualTo(100L);
+        assertThat(exceptions).hasSize(threadCount - 1);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("단일 호출 수행 시간이 수백 ms 이내다 (락 보유 시간 기준선)")
+    void completeQuizSession_수행_시간이_수백ms_이내다() {
+        // given / when
+        long start = System.currentTimeMillis();
+        quizPlayService.completeQuizSession(memberAccountId, sessionId);
+        long elapsed = System.currentTimeMillis() - start;
+
+        // then
+        System.out.println("completeQuizSession 수행 시간: " + elapsed + "ms");
+        assertThat(elapsed).isLessThan(500L);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

**분리배출 인증 사이클(쓰레기 촬영 → 가이드 확인 → 체크리스트 → 퀴즈) 완료 시 `조개`(10개), `연료`(100), `경험치` 보상을 지급합니다.**

### Feature
- `POST /v1/quizzes/sessions/{sessionId}/complete` 호출 시 조개(10), 연료(100), 경험치 지급
- 이미 만료된 세션 재요청 시 `EXPIRED_QUIZ_SESSION` 예외로 중복 보상 방지
- `RecyclingRewardResponse` DTO 신규 추가 (`earnedShell`, `earnedFuel`, `earnedExp`)
- `RecyclingRewardCalculator` 컴포넌트 신규 추가: 추후 건물 효과에 따른 조개 지급량 추가 시, 이 클래스만 수정하도록

### Refactor
- `addRecyclingExp` 시그니처를 `Long memberAccountId` → `MemberIsland island`로 변경
  - 호출자가 락 획득 후 island를 로드하여 넘기는 방식으로 `IslandLevelService` 내부 중복 조회 제거

### Test
- `IslandLevelServiceConcurrencyTest` 재작성: 시그니처 변경에 따라 테스트 방식 변경 (상세 설명 참고)

## 상세 설명

- `completeQuizSession`은 세션 만료와 보상 지급을 하나의 트랜잭션 안에서 처리합니다.
세션이 이미 만료된 경우 예외를 던지므로 재호출 시 중복 보상이 발생하지 않습니다.

- `RecyclingRewardCalculator`는 현재 조개 고정값(10)을 반환하지만, 
추후 재활용 분류기(`DISPOSAL_REWARD_ADD`) 나 대기 정화 타워(`QUIZ_REWARD_ADD`)와 같은 건물 효과에 따라 조개를 더 추가로 지급하게 될때, 
이 컴포넌트 내부 `RecyclingRewardCalculator.calculateShell`에 별도 서비스(e.g. `BuildingEffectService`?)를 주입하는 것만으로 확장 가능하도록 분리했습니다. (혹시 잘못 이해한 거면 말씀해주세요!! cc. @abookhui)

## 체크리스트

- [x] 이미 만료된 세션 재요청 시 중복 보상 방지 확인
- [x] 동시성 테스트 통과 확인

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-441?atlOrigin=eyJpIjoiYmFhYjk1NDdlYjViNDYxY2I0OGZhOTk2ODZlZjRhNmQiLCJwIjoiaiJ9

## 참고사항

### 1. 락 전략 관련 논의
현재 `QuizPlayService.completeQuizSession`은 조개, 연료, 경험치 세 리소스를 동시에 건드리기 때문에 락을 세 개 잡고 있는데요,
```java
@DistributedLock(keys = {
    "'island:' + #memberAccountId + ':exp'",
    "'island:' + #memberAccountId + ':shell'",
    "'island:' + #memberAccountId + ':fuel'"
})
@Transactional
public RecyclingRewardResponse completeQuizSession(Long memberAccountId, Long sessionId) {
```
지금과 같은 **A. 리소스별 분산 락 (현재 방식) vs B. 섬 단위 단일 락으로 아예 통일 (`'island:{id}'`)** 
두 방식 중 어느 방향이 나을지 의견 부탁드립니다.

A. [리소스별 분산 락] 
- 장점: 서로 다른 리소스만 건드리는 작업끼리는 병렬 실행 가능 (예: 경험치만 건드리는 작업과 조개만 건드리는 작업은 동시 진행 가능).
`DistributedLockAspect`가 `Collections.sort(keys)`로 락 획득 순서를 고정하여 데드락을 방지하고 있음

- 단점: `completeQuizSession`처럼 여러 락을 동시에 잡는 메서드가 있으면 세분화 이점이 사라짐
예를 들어 "조개만 변경하는 작업"이 `:shell` 락을 획득하려 해도, `completeQuizSession`이 세 락을 메서드 전체가 끝날 때까지 유지하기 때문에 경험치, 연료 처리가 끝날 때까지 기다려야 함
세분화 이점을 살리려면 각 락을 해당 리소스 처리 직후 해제해야 하는데, 그러면 세 리소스 간 원자성이 깨짐. 또한 여러 리소스를 건드리는 메서드가 생길 때마다 락 목록을 수동으로 관리해야 하는 부담도 있음

B. [섬 단위 단일 락]

- 장점: 관리가 단순하고, 섬에 대한 모든 변경이 자동으로 직렬화되어 누락 위험 없음
- 단점: 세분성이 낮아지며, 서로 무관한 리소스 작업도 직렬화되어 이론상 처리량이 줄어들 수 있음

(저는 재화 종류가 다양하기도 하고, 필요한 리소스에만 락을 거는 방식으로 세분화 하는 게 맞다고 생각해서 A가 더 낫다고 판단했습니다만..! 한 메서드가 락을 세 개나 잡는 게 이게 괜찮은 건지 잘 모르겠어서,, 더 나은 방향이 있을까해서 여쭤봅니당. @abookhui @sonyk9919)

### 2. 동시성 테스트 재작성 배경
기존 테스트는 `addRecyclingExp(Long memberAccountId)` 시그니처 기준으로 
"스레드 3개가 동시에 호출하면 경험치가 300이어야 한다"는 누적값을 검증하는 방식이었습니다.

이번에 중복 조회를 방지하기 위해 시그니처가 `addRecyclingExp(MemberIsland island)`로 바뀌면서 호출자가 `island`를 미리 로드해서 넘기는 구조가 됐는데, 
락 바깥에서 `island`를 로드하면 세 스레드가 모두 `exp=0`인 스테일 상태를 읽고 각자 `exp=100`으로 덮어쓰게 됩니다. 
결과적으로 누적값 검증이 불가능한 구조가 됐습니다.

대신 "락이 이미 점유 중일 때 두 번째 호출이 409를 반환하는지" 를 검증하는 방향으로 재작성했습니다. 
메인 스레드가 직접 `redissonClient`로 락을 선점한 뒤, 별도 스레드에서 `addRecyclingExp`를 호출해 `LOCK_ACQUISITION_FAILED` 예외가 던져지는지 확인합니다.

참고 부탁드립니다!

### 3. 보상 지급 API 분리 여부
분리배출 인증 사이클 완료(= 퀴즈 풀이 완료)에 따른 보상 지급은 함께 발생해야 하는 원자적 작업이라고 판단해서
`퀴즈 세션 완료`와 `보상 지급`을 하나의 API, 하나의 트랜잭션 안에서 처리하고, 이미 만료된 세션으로 재요청 시 예외를 던지는 방식으로 중복 지급을 자연스럽게 막는 방식으로 구현했는데요!

혹시 클라이언트 UI 흐름상 별도의 보상 요청하는 API로 분리하는 방식이 더 편하실지 의견 부탁드립니다! 편하신 대로 구현해볼게요! (cc. @sonyk9919)

### 4. 분리배출 인증 사이클 완료 시 지급되는 연료량 100으로 설정
기획서 살펴봤을 때 필요 연료량이 일단 가장 저렴한 게 풍력 발전소(☢️ 1,000)이더라구요!
그래서 일단 임의로 100으로 설정해봤는데 변경 필요할 것 같으면 말씀 부탁드립니다.