### PR TITLE
fix: 슬롯에 빈 건물있으면 예외 던지는 오류 수정

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
@@ -34,6 +34,7 @@ public class BuildingHarvestService {
         Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
 
+        if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
         Building building = slot.getBuilding();
 
         HarvestCalculator calculator = HarvestCalculator.of(building, LocalDateTime.now());

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingLayoutService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingLayoutService.java
@@ -68,9 +68,9 @@ public class BuildingLayoutService {
     public void demolishOf(Long memberId, Integer slotNumber) {
         Slot slot = getSlot(memberId, slotNumber);
         MemberIsland island = slot.getIsland();
-        Building building = slot.getBuilding();
 
-        if (building == null) throw new CustomException(SlotStatus.SLOT_EMPTY);
+        if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
+        Building building = slot.getBuilding();
 
         addResource(island, building.getCurrentYield());
         slot.demolish();
@@ -91,9 +91,10 @@ public class BuildingLayoutService {
     public void levelUp(Long memberId, Integer slotNumber){
         Slot slot = getSlot(memberId, slotNumber);
         MemberIsland island = slot.getIsland();
+
+        if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
         Building building = slot.getBuilding();
 
-        if (building == null) throw new CustomException(SlotStatus.SLOT_EMPTY);
         if (building.isOperating()) throw new CustomException(BuildingStatus.ALREADY_OPERATING);
 
         subtractResource(island, building.getNextYield());

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.building.entity.Building;
 import store.sonyk9919.api.domain.building.entity.BuildingYield;
+import store.sonyk9919.api.domain.building.exception.BuildingStatus;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.entity.ResourceType;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
@@ -27,6 +28,8 @@ public class BuildingOperateService {
     @Transactional
     public void operate(Long memberId, Integer slotNumber) {
         Slot slot = getSlot(memberId, slotNumber);
+
+        if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
         Building building = slot.getBuilding();
         BuildingYield yield = building.getCurrentYield();
 

--- a/src/main/java/store/sonyk9919/api/domain/building/service/IslandBoostCache.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/IslandBoostCache.java
@@ -10,6 +10,7 @@ import store.sonyk9919.api.domain.building.entity.Building;
 import store.sonyk9919.api.domain.building.entity.BuildingEffect;
 import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 
 @Component
@@ -23,7 +24,7 @@ public class IslandBoostCache {
     public double getTotalBoost(MemberIsland island) {
         return slotRepository.findAllByIsland(island).stream()
                 .filter(Objects::nonNull)
-                .filter(s -> s.getBuilding() != null)
+                .filter(Slot::hasBuilding)
                 .map(s -> {
                     Building building = s.getBuilding();
                     BuildingMetadata metadata = building.getBuildingMetadata();

--- a/src/main/java/store/sonyk9919/api/domain/slot/entity/Slot.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/entity/Slot.java
@@ -59,12 +59,6 @@ public class Slot {
         return building != null;
     }
 
-    public Building getBuilding(){
-        if(building == null) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
-
-        return building;
-    }
-
     public void activate() {
         if (activated) throw new CustomException(SlotStatus.SLOT_ALREADY_ACTIVATED);
 

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -17,7 +17,6 @@ import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
-import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.exception.SlotStatus;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.global.common.exception.CustomException;
@@ -36,7 +35,7 @@ public class SlotQueryService {
 
         return slotRepository.findAllByIsland(island)
                 .stream()
-                .map(slot -> SlotResponseDto.of(slot, mapToBuildingInfo(getBuilding(slot))))
+                .map(slot -> SlotResponseDto.of(slot, mapToBuildingInfo(slot.getBuilding())))
                 .collect(Collectors.toList());
     }
 
@@ -46,16 +45,11 @@ public class SlotQueryService {
         return BuildingInfoDto.of(building, building.getBuildingMetadata());
     }
 
-    private Building getBuilding(Slot slot) {
-        if(!slot.hasBuilding()) return null;
-        return slot.getBuilding();
-    }
-
     public SlotDetailResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
         return slotRepository.findByIslandAndSlotNumber(island, slotNumber)
-                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(island, getBuilding(slot))))
+                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(island, slot.getBuilding())))
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
     }
 

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -17,6 +17,7 @@ import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
+import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.exception.SlotStatus;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.global.common.exception.CustomException;
@@ -35,7 +36,7 @@ public class SlotQueryService {
 
         return slotRepository.findAllByIsland(island)
                 .stream()
-                .map(slot -> SlotResponseDto.of(slot, mapToBuildingInfo(slot.getBuilding())))
+                .map(slot -> SlotResponseDto.of(slot, mapToBuildingInfo(getBuilding(slot))))
                 .collect(Collectors.toList());
     }
 
@@ -45,11 +46,16 @@ public class SlotQueryService {
         return BuildingInfoDto.of(building, building.getBuildingMetadata());
     }
 
+    private Building getBuilding(Slot slot) {
+        if(!slot.hasBuilding()) return null;
+        return slot.getBuilding();
+    }
+
     public SlotDetailResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
         return slotRepository.findByIslandAndSlotNumber(island, slotNumber)
-                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(island, slot.getBuilding())))
+                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(island, getBuilding(slot))))
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
     }
 

--- a/src/test/java/store/sonyk9919/api/domain/building/service/BuildingLayoutServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/building/service/BuildingLayoutServiceTest.java
@@ -87,6 +87,7 @@ class BuildingLayoutServiceTest {
         BuildingYield yield = mock(BuildingYield.class);
 
         given(slot.getIsland()).willReturn(island);
+        given(slot.hasBuilding()).willReturn(true);
         given(slot.getBuilding()).willReturn(building);
         given(building.getCurrentYield()).willReturn(yield);
         given(yield.getRefundShell()).willReturn(50);
@@ -108,6 +109,7 @@ class BuildingLayoutServiceTest {
         // given
         Building building = mock(Building.class);
 
+        given(slot.hasBuilding()).willReturn(true);
         given(slot.getBuilding()).willReturn(building);
         given(building.isOperating()).willReturn(true);
 


### PR DESCRIPTION
## 주요 변경사항

- 관련 이슈: #56 
- 전체 슬롯 조회 시 건물이 없는 빈 슬롯이 있으면 예외를 던지는 걸 수정했습니다.


## 상세 설명

- **원인**: 기존 `SlotQueryService`에서 모든 슬롯을 돌며 `slot.getBuilding()`을 호출해 건물이 없는 슬롯의 경우 엔티티 내부에서 예외가 발생했습니다.
- **해결**: `hasBuilding()`을 먼저 확인해서 건물이 없는 슬롯은 예외 대신 `null`을 반환하도록 수정했습니다.
- **결과**: 빈 슬롯은 `building: null`로 래핑되어 유저의 전체 슬롯 목록이 반환 됩니다.

## Jira 링크

## 참고사항

- 카카오 로그인 후 조회 시 반환
```json

{
  "code": "COMMON_200",
  "message": "성공입니다.",
  "data": [
    {
      "activated": false,
      "building": null,
      "slotNumber": 1
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 2
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 3
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 4
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 5
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 6
    },
    {
      "activated": false,
      "building": null,
      "slotNumber": 7
    }
  ]
}
```

- 클라이언트에서 급하시면 확인 후 바로 병합하셔도 됩니다! 