### PR TITLE
fix: 섬 생성 시 재화 엔티티가 생성되지 않는 문제 수정

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/dto/ResourceBalanceResponse.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/ResourceBalanceResponse.java
@@ -22,9 +22,9 @@ public class ResourceBalanceResponse {
                 .collect(Collectors.toMap(MemberResource::getResourceType, MemberResource::getAmount));
 
         return new ResourceBalanceResponse(
-                amounts.getOrDefault(ResourceType.SHELL, 0L),
-                amounts.getOrDefault(ResourceType.GEM, 0L),
-                amounts.getOrDefault(ResourceType.FUEL, 0L)
+                amounts.get(ResourceType.SHELL),
+                amounts.get(ResourceType.GEM),
+                amounts.get(ResourceType.FUEL)
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -20,6 +20,7 @@ public class MemberIslandRegistryService {
     private final MemberIslandRepository memberIslandRepository;
     private final MemberAccountService memberAccountService;
     private final SlotSetupService slotSetupService;
+    private final ResourceSetupService resourceSetupService;
 
     @Transactional
     public MemberIsland create(Long memberAccountId, String nickname) {
@@ -37,6 +38,7 @@ public class MemberIslandRegistryService {
         MemberIsland island = MemberIsland.create(nickname, account);
         memberIslandRepository.save(island);
         slotSetupService.setupSlots(island);
+        resourceSetupService.setupResources(island);
         return island;
     }
 

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ResourceService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ResourceService.java
@@ -58,6 +58,8 @@ public class ResourceService {
 
     public ResourceBalanceResponse getBalance(Long memberAccountId) {
         List<MemberResource> resources = memberResourceRepository.findAllByIslandMemberAccountId(memberAccountId);
+        if (resources.size() != ResourceType.values().length)
+            throw new CustomException(ResourceStatus.RESOURCE_NOT_FOUND);
         return ResourceBalanceResponse.from(resources);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSetupService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ResourceSetupService.java
@@ -1,0 +1,26 @@
+package store.sonyk9919.api.domain.island.service;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+import store.sonyk9919.api.domain.island.repository.MemberResourceRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ResourceSetupService {
+
+    private final MemberResourceRepository memberResourceRepository;
+
+    @Transactional
+    public void setupResources(MemberIsland island) {
+        List<MemberResource> resources = Arrays.stream(ResourceType.values())
+                .map(type -> MemberResource.create(type, island))
+                .toList();
+        memberResourceRepository.saveAll(resources);
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/island/service/ResourceSetupServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/ResourceSetupServiceTest.java
@@ -1,0 +1,72 @@
+package store.sonyk9919.api.domain.island.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import store.sonyk9919.api.domain.auth.dto.OAuthUserInfoDto;
+import store.sonyk9919.api.domain.auth.entity.OAuthProviderType;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.domain.island.repository.MemberResourceRepository;
+import store.sonyk9919.api.domain.member.entity.AccountRole;
+import store.sonyk9919.api.domain.member.entity.MemberAccount;
+import store.sonyk9919.api.domain.member.repository.MemberAccountRepository;
+import store.sonyk9919.api.global.config.QueryDslConfig;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, ResourceSetupService.class})
+class ResourceSetupServiceTest {
+
+    @Autowired private ResourceSetupService resourceSetupService;
+    @Autowired private MemberAccountRepository memberAccountRepository;
+    @Autowired private MemberIslandRepository memberIslandRepository;
+    @Autowired private MemberResourceRepository memberResourceRepository;
+
+    private MemberIsland savedIsland;
+
+    @BeforeEach
+    void setUp() {
+        OAuthUserInfoDto userInfo = mock(OAuthUserInfoDto.class);
+        given(userInfo.getId()).willReturn("test-" + System.nanoTime());
+        MemberAccount account = memberAccountRepository.save(
+                MemberAccount.from(userInfo, OAuthProviderType.KAKAO, AccountRole.USER)
+        );
+        savedIsland = memberIslandRepository.save(MemberIsland.create("테스트 섬", account));
+    }
+
+    @Test
+    void setupResources_섬_생성_시_SHELL_GEM_FUEL_재화가_0으로_생성된다() {
+        // when
+        resourceSetupService.setupResources(savedIsland);
+
+        // then
+        List<MemberResource> resources = memberResourceRepository.findAllByIslandMemberAccountId(
+                savedIsland.getMemberAccount().getId()
+        );
+        assertThat(resources).hasSize(3);
+        assertThat(resources).allMatch(r -> r.getAmount() == 0);
+    }
+
+    @Test
+    void setupResources_재화_타입이_모두_생성된다() {
+        // when
+        resourceSetupService.setupResources(savedIsland);
+
+        // then
+        List<MemberResource> resources = memberResourceRepository.findAllByIslandMemberAccountId(
+                savedIsland.getMemberAccount().getId()
+        );
+        assertThat(resources)
+                .extracting(MemberResource::getResourceType)
+                .containsExactlyInAnyOrder(ResourceType.SHELL, ResourceType.GEM, ResourceType.FUEL);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- 섬 생성 시 `SHELL`, `GEM`, `FUEL` 재화 엔티티가 초기화되지 않던 문제를 수정합니다.

### Feature
- `ResourceSetupService` 신규 추가: 섬 생성 시 재화 3종을 `amount=0`으로 초기화
- `MemberIslandRegistryService.createEntity()`에서 `resourceSetupService.setupResources(island)` 호출

### Fix
- `ResourceService.getBalance()`에 재화 개수 검증 추가: 비정상 상태 시 `RESOURCE_NOT_FOUND` 예외 발생
- `ResourceBalanceResponse.from()`의 `getOrDefault(0L)` → `get()` 변경

### Test
- `ResourceSetupServiceTest` 추가: 재화 3개 생성 및 타입(`SHELL`/`GEM`/`FUEL`) 검증

## 상세 설명
- 원인: 기존 `MemberIslandRegistryService.createEntity()`는 섬 생성 후 슬롯만 초기화하고 재화는 초기화하지 않고 있었습니다.
- 이로 인해 `ResourceService.add()` / `subtract()` 등 재화 조회 시 `RESOURCE_NOT_FOUND` 예외가 발생했고, `GET /v1/resources`는 DB의 `null`을 `0`으로 변환해 실제 값과 불일치가 있었습니다.
- `SlotSetupService`와 동일한 책임 분리 패턴으로 `ResourceSetupService`를 신설해 해결했습니다.

## 체크리스트

- [x] 섬 생성 API 호출 후 h2 콘솔 `MEMBER_RESOURCE` 테이블에 SHELL/GEM/FUEL 3개 레코드 생성 확인
- [x] `GET /v1/resources` 응답이 `{shell: 0, gem: 0, fuel: 0}` 반환 확인

## 참고사항
CLOSES #59 