### PR TITLE
fix: 슬롯 활성화 조건 명시하도록 수정

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotDetailResponseDto.java
@@ -13,12 +13,14 @@ public class SlotDetailResponseDto {
     private Integer slotNumber;
     private boolean activated;
     private BuildingDetailDto building;
+    private SlotUnlockResource resource;
 
-    public static SlotDetailResponseDto of(Slot slot, BuildingDetailDto buildingDto) {
+    public static SlotDetailResponseDto of(Slot slot, BuildingDetailDto buildingDto, SlotUnlockResource resource) {
         return new SlotDetailResponseDto(
                 slot.getSlotNumber(),
                 slot.isActivated(),
-                buildingDto
+                buildingDto,
+                resource
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotUnlockResource.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotUnlockResource.java
@@ -1,0 +1,17 @@
+package store.sonyk9919.api.domain.slot.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SlotUnlockResource {
+    private ResourceType resourceType;
+    private int unlockCost;
+
+    public static SlotUnlockResource of(ResourceType type, int unlockCost) {
+        return new SlotUnlockResource(type, unlockCost);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -14,9 +14,13 @@ import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
 import store.sonyk9919.api.domain.building.service.HarvestCalculator;
 import store.sonyk9919.api.domain.building.service.IslandBoostCache;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.ResourceType;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.slot.dto.SlotDetailResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
+import store.sonyk9919.api.domain.slot.dto.SlotUnlockResource;
+import store.sonyk9919.api.domain.slot.entity.Slot;
+import store.sonyk9919.api.domain.slot.entity.SlotUnlockPolicy;
 import store.sonyk9919.api.domain.slot.exception.SlotStatus;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.global.common.exception.CustomException;
@@ -48,9 +52,17 @@ public class SlotQueryService {
     public SlotDetailResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
         MemberIsland island = memberIslandService.getIsland(memberId);
 
-        return slotRepository.findByIslandAndSlotNumber(island, slotNumber)
-                .map(slot -> SlotDetailResponseDto.of(slot, mapToBuildingDetail(island, slot.getBuilding())))
+        Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
+
+        SlotUnlockResource slotUnlockResource = !slot.isActivated() ?
+                calculateUnlockCost(island) : null;
+
+        return SlotDetailResponseDto.of(
+                slot,
+                mapToBuildingDetail(island, slot.getBuilding()),
+                slotUnlockResource
+        );
     }
 
     private BuildingDetailDto mapToBuildingDetail(MemberIsland island, Building building) {
@@ -78,5 +90,12 @@ public class SlotQueryService {
 
         HarvestCalculator calculator = HarvestCalculator.of(building, LocalDateTime.now());
         return calculator.calculate(boostPercent);
+    }
+
+    private SlotUnlockResource calculateUnlockCost(MemberIsland island) {
+        return SlotUnlockResource.of(
+                ResourceType.SHELL,
+                SlotUnlockPolicy.costFor(slotRepository.countByIslandAndActivatedTrue(island))
+        );
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- #57 활성화 조건을 명시하기 위해 재화 관련 필드를 추가했습니다.


## 참고사항

- 로그인 후 특정 슬롯을 조회하면 비활성화 시 재화 관련 조건을 반환해 줍니다. ( 이미 활성화된 상태라면 null 반환합니다.)
<img width="499" height="262" alt="image" src="https://github.com/user-attachments/assets/638c84b3-ef73-4862-b5f5-9c4245a6ab3a" />
