### PR TITLE
feat: 슬롯 활성화 비용 조회 API

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/controller/SlotController.java
@@ -1,6 +1,9 @@
 package store.sonyk9919.api.domain.slot.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,7 @@ import store.sonyk9919.api.domain.auth.entity.AuthMember;
 import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotListResponseDto;
+import store.sonyk9919.api.domain.slot.dto.SlotUnlockResource;
 import store.sonyk9919.api.domain.slot.service.SlotActivateService;
 import store.sonyk9919.api.domain.slot.service.SlotQueryService;
 
@@ -73,5 +77,17 @@ public class SlotController {
             @PathVariable Integer slotNumber
     ) {
       return slotActivateService.activate(authMember.getId(), slotNumber);
+    }
+
+    @Operation(summary = "슬롯 활성화 비용 조회", description = "현재 사용자의 슬롯 잠금 해제 비용을 계산하여 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "슬롯 잠금 해제 비용 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SlotUnlockResource.class))),
+    })
+    @GetMapping("/activate")
+    public SlotUnlockResource getResourceOfActivate(
+            @Parameter(hidden = true) @AuthMember AuthMemberDto authMemberDto
+    ) {
+        return slotActivateService.calculateUnlockCost(authMemberDto.getId());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotActivateResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotActivateResponseDto.java
@@ -11,8 +11,13 @@ public class SlotActivateResponseDto {
 
     private SlotResponseDto slot;
     private ResourceBalanceResponse resource;
+    private SlotUnlockResource nextCost;
 
-    public static SlotActivateResponseDto of(SlotResponseDto slot, ResourceBalanceResponse resource){
-        return new SlotActivateResponseDto(slot, resource);
+    public static SlotActivateResponseDto of(SlotResponseDto slot, ResourceBalanceResponse resource, SlotUnlockResource nextCost){
+        return new SlotActivateResponseDto(
+                slot,
+                resource,
+                nextCost
+        );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotResponseDto.java
@@ -13,22 +13,12 @@ public class SlotResponseDto {
     private Integer slotNumber;
     private boolean activated;
     private BuildingInfoDto building;
-    private SlotUnlockResource resource;
 
     public static SlotResponseDto from(Slot slot) {
         return new SlotResponseDto(
                 slot.getSlotNumber(),
                 slot.isActivated(),
-                null, null
-        );
-    }
-
-    public static SlotResponseDto of(Slot slot, BuildingInfoDto buildingDto, SlotUnlockResource resource) {
-        return new SlotResponseDto(
-                slot.getSlotNumber(),
-                slot.isActivated(),
-                buildingDto,
-                resource
+                null
         );
     }
 
@@ -36,8 +26,7 @@ public class SlotResponseDto {
         return new SlotResponseDto(
                 slot.getSlotNumber(),
                 slot.isActivated(),
-                buildingDto,
-                null
+                buildingDto
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotUnlockResource.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/dto/SlotUnlockResource.java
@@ -3,15 +3,14 @@ package store.sonyk9919.api.domain.slot.dto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import store.sonyk9919.api.domain.island.entity.ResourceType;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SlotUnlockResource {
-    private ResourceType resourceType;
-    private int unlockCost;
 
-    public static SlotUnlockResource of(ResourceType type, int unlockCost) {
-        return new SlotUnlockResource(type, unlockCost);
+    private int shell;
+
+    public static SlotUnlockResource of(int unlockCost) {
+        return new SlotUnlockResource(unlockCost);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotActivateService.java
@@ -11,6 +11,7 @@ import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.island.service.ResourceService;
 import store.sonyk9919.api.domain.slot.dto.SlotActivateResponseDto;
 import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
+import store.sonyk9919.api.domain.slot.dto.SlotUnlockResource;
 import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.entity.SlotUnlockPolicy;
 import store.sonyk9919.api.domain.slot.exception.SlotStatus;
@@ -42,7 +43,8 @@ public class SlotActivateService {
 
         return SlotActivateResponseDto.of(
                 SlotResponseDto.from(slot),
-                resourceService.getBalance(memberId)
+                resourceService.getBalance(memberId),
+                SlotUnlockResource.of(SlotUnlockPolicy.costFor(activeCount + 1))
         );
     }
 
@@ -52,5 +54,10 @@ public class SlotActivateService {
         if (activeCount >= currentLevelSpec.getMaxSlotCount()) {
             throw new CustomException(SlotStatus.EXCEED_MAX_SLOT_FOR_LEVEL);
         }
+    }
+
+    public SlotUnlockResource calculateUnlockCost(Long memberId) {
+        MemberIsland island = memberIslandService.getIsland(memberId);
+        return SlotUnlockResource.of(SlotUnlockPolicy.costFor(slotRepository.countByIslandAndActivatedTrue(island)));
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -41,14 +41,12 @@ public class SlotQueryService {
 
         LevelSpec levelSpec = levelSpecCache.get(island.getLevel());
         int maxActivatableSlots = levelSpec.getMaxSlotCount();
-        SlotUnlockResource resource = calculateUnlockCost(island);
 
         List<SlotResponseDto> slots = slotRepository.findAllByIsland(island)
                 .stream()
                 .map(slot -> SlotResponseDto.of(
                         slot,
-                        mapToBuildingInfo(slot.getBuilding()),
-                        !slot.isActivated() ? resource : null
+                        mapToBuildingInfo(slot.getBuilding())
                 ))
                 .collect(Collectors.toList());
 
@@ -67,14 +65,7 @@ public class SlotQueryService {
         Slot slot = slotRepository.findByIslandAndSlotNumber(island, slotNumber)
                 .orElseThrow(() -> new CustomException(SlotStatus.SLOT_NOT_FOUND));
 
-        SlotUnlockResource resource = !slot.isActivated() ?
-                calculateUnlockCost(island) : null;
-
-        return SlotResponseDto.of(
-                slot,
-                mapToBuildingDetail(island, slot.getBuilding()),
-                resource
-        );
+        return SlotResponseDto.of(slot, mapToBuildingDetail(island, slot.getBuilding()));
     }
 
     private BuildingInfoDto mapToBuildingDetail(MemberIsland island, Building building) {
@@ -102,12 +93,5 @@ public class SlotQueryService {
 
         HarvestCalculator calculator = HarvestCalculator.of(building, LocalDateTime.now());
         return calculator.calculate(boostPercent);
-    }
-
-    private SlotUnlockResource calculateUnlockCost(MemberIsland island) {
-        return SlotUnlockResource.of(
-                ResourceType.SHELL,
-                SlotUnlockPolicy.costFor(slotRepository.countByIslandAndActivatedTrue(island))
-        );
     }
 }


### PR DESCRIPTION
## 주요 변경사항
### Feature
- 슬롯 활성화 비용 조회 API를 추가하였습니다.

## 상세 설명
- 아래 API에서 비활성화된 슬롯인 경우 응답에 활성화 비용이 전달되는 부분을 제거하였습니다.
  - GET /v1/slots
  - GET /v1/slots/{slotNumber}
- 분리한 이유는 활성화된 슬롯이 늘어날 수록 슬롯 활성화 비용이 증가하기 때문입니다. 이 경우에 슬롯 활성화 시마다 클라이언트가 저장 중인 모든 비활성 슬롯의 cache revalidate가 필요한데 이를 피하기 위해 `/v1/slots/activate`를 통해 활성화 비용을 별도로 조회할 수 있도록 분리했습니다.

## 참고사항
단순 API 분리이므로 Approve 없이 병합하겠습니다. 궁금하신 사항은 댓글이나 DM 부탁드립니다.