### PR TITLE
feat: GET /v1/islands 응답에 다음 레벨 도달 조건 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
@@ -13,14 +13,16 @@ public class MemberIslandDto {
     private final int cumulativeExp;
     private final int recyclingContributionExp;
     private final int itemContributionExp;
+    private final NextLevelConditionDto nextLevel;
 
-    public static MemberIslandDto from(MemberIsland island) {
+    public static MemberIslandDto from(MemberIsland island, NextLevelConditionDto nextLevel) {
         return new MemberIslandDto(
                 island.getNickname(),
                 island.getLevel(),
                 island.getCumulativeExp(),
                 island.getRecyclingContributionExp(),
-                island.getItemContributionExp()
+                island.getItemContributionExp(),
+                nextLevel
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDto.java
@@ -1,0 +1,25 @@
+package store.sonyk9919.api.domain.island.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class NextLevelConditionDto {
+    private final int totalRequiredExp;
+    private final int recyclingExpLimit;
+    private final boolean itemRequired;
+
+    public static NextLevelConditionDto from(LevelSpec currentSpec, MemberIsland island) {
+        int remainingExp = currentSpec.getRequiredExp() - island.getCumulativeExp();
+        int remainingRecyclingExp = currentSpec.getRecyclingContributionExpLimit() - island.getRecyclingContributionExp();
+        return new NextLevelConditionDto(
+                currentSpec.getRequiredExp(),
+                currentSpec.getRecyclingContributionExpLimit(),
+                remainingRecyclingExp < remainingExp
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDto.java
@@ -4,22 +4,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
-import store.sonyk9919.api.domain.island.entity.MemberIsland;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class NextLevelConditionDto {
     private final int totalRequiredExp;
     private final int recyclingExpLimit;
-    private final boolean itemRequired;
 
-    public static NextLevelConditionDto from(LevelSpec currentSpec, MemberIsland island) {
-        int remainingExp = currentSpec.getRequiredExp() - island.getCumulativeExp();
-        int remainingRecyclingExp = currentSpec.getRecyclingContributionExpLimit() - island.getRecyclingContributionExp();
+    public static NextLevelConditionDto from(LevelSpec currentSpec) {
         return new NextLevelConditionDto(
                 currentSpec.getRequiredExp(),
-                currentSpec.getRecyclingContributionExpLimit(),
-                remainingRecyclingExp < remainingExp
+                currentSpec.getRecyclingContributionExpLimit()
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/entity/MemberIsland.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/MemberIsland.java
@@ -78,9 +78,9 @@ public class MemberIsland {
         cumulativeExp += expAmount;
     }
 
-    public boolean canLevelUp(LevelSpec nextSpec) {
+    public boolean canLevelUp(LevelSpec currentSpec) {
         if (isMaxLevel()) return false;
-        return cumulativeExp >= nextSpec.getRequiredExp();
+        return cumulativeExp >= currentSpec.getRequiredExp();
     }
 
     public void levelUp() {

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -48,8 +48,8 @@ public class IslandLevelService {
     private LevelUpResult checkAndProcessLevelUp(MemberIsland island) {
         if (island.isMaxLevel()) return LevelUpResult.noLevelUp(MemberIslandDto.from(island));
 
-        LevelSpec nextSpec = getLevelSpec(island.getLevel() + 1);
-        if (!island.canLevelUp(nextSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island));
+        LevelSpec currentSpec = getLevelSpec(island.getLevel());
+        if (!island.canLevelUp(currentSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island));
 
         island.levelUp();
         return buildLevelUpResult(island);

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -9,6 +9,7 @@ import store.sonyk9919.api.domain.building.service.BuildingMetadataCache;
 import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
 import store.sonyk9919.api.domain.island.dto.LevelUpResult;
 import store.sonyk9919.api.domain.island.dto.MemberIslandDto;
+import store.sonyk9919.api.domain.island.dto.NextLevelConditionDto;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.exception.IslandStatus;
@@ -46,10 +47,10 @@ public class IslandLevelService {
     }
 
     private LevelUpResult checkAndProcessLevelUp(MemberIsland island) {
-        if (island.isMaxLevel()) return LevelUpResult.noLevelUp(MemberIslandDto.from(island));
+        if (island.isMaxLevel()) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, null));
 
         LevelSpec currentSpec = getLevelSpec(island.getLevel());
-        if (!island.canLevelUp(currentSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island));
+        if (!island.canLevelUp(currentSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, buildNextLevelCondition(island)));
 
         island.levelUp();
         return buildLevelUpResult(island);
@@ -59,15 +60,21 @@ public class IslandLevelService {
         boolean reachedMaxLevel = island.isMaxLevel();
         if (reachedMaxLevel) {
             return LevelUpResult.of(
-                    MemberIslandDto.from(island),
+                    MemberIslandDto.from(island, null),
                     LevelUpResult.UnlockNotice.of(true, List.of(), List.of())
             );
         }
         int newLevel = island.getLevel();
         return LevelUpResult.of(
-                MemberIslandDto.from(island),
+                MemberIslandDto.from(island, buildNextLevelCondition(island)),
                 LevelUpResult.UnlockNotice.of(false, getUnlockedItems(newLevel), getUnlockedBuildings(newLevel))
         );
+    }
+
+    private NextLevelConditionDto buildNextLevelCondition(MemberIsland island) {
+        if (island.isMaxLevel()) return null;
+        LevelSpec currentSpec = getLevelSpec(island.getLevel());
+        return NextLevelConditionDto.from(currentSpec);
     }
 
     private List<ItemCatalogDto> getUnlockedItems(int newLevel) {

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -59,6 +59,6 @@ public class MemberIslandRegistryService {
     private NextLevelConditionDto buildNextLevelCondition(MemberIsland island) {
         if (island.isMaxLevel()) return null;
         LevelSpec currentSpec = levelSpecCache.get(island.getLevel());
-        return NextLevelConditionDto.from(currentSpec, island);
+        return NextLevelConditionDto.from(currentSpec);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.dto.MemberIslandDto;
+import store.sonyk9919.api.domain.island.dto.NextLevelConditionDto;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
@@ -21,6 +23,7 @@ public class MemberIslandRegistryService {
     private final MemberAccountService memberAccountService;
     private final SlotSetupService slotSetupService;
     private final ResourceSetupService resourceSetupService;
+    private final LevelSpecCache levelSpecCache;
 
     @Transactional
     public MemberIsland create(Long memberAccountId, String nickname) {
@@ -30,7 +33,7 @@ public class MemberIslandRegistryService {
     @Transactional
     public MemberIslandDto createDto(Long memberAccountId, String nickname) {
         MemberIsland island = createEntity(memberAccountId, nickname);
-        return MemberIslandDto.from(island);
+        return MemberIslandDto.from(island, buildNextLevelCondition(island));
     }
 
     private MemberIsland createEntity(Long memberAccountId, String nickname) {
@@ -50,6 +53,12 @@ public class MemberIslandRegistryService {
     public MemberIslandDto getIslandDto(Long memberAccountId) {
         MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
                 .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
-        return MemberIslandDto.from(island);
+        return MemberIslandDto.from(island, buildNextLevelCondition(island));
+    }
+
+    private NextLevelConditionDto buildNextLevelCondition(MemberIsland island) {
+        if (island.isMaxLevel()) return null;
+        LevelSpec currentSpec = levelSpecCache.get(island.getLevel());
+        return NextLevelConditionDto.from(currentSpec, island);
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDtoTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDtoTest.java
@@ -8,22 +8,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
-import store.sonyk9919.api.domain.island.entity.MemberIsland;
 
 @ExtendWith(MockitoExtension.class)
 class NextLevelConditionDtoTest {
 
     @Test
-    void from_레벨1_초기상태_itemRequired가_false다() {
+    void from_totalRequiredExp와_recyclingExpLimit이_currentSpec_값으로_설정된다() {
         // given
-        LevelSpec spec = mockSpec(500, 500);
-        MemberIsland island = mockIsland(0, 0);
+        LevelSpec spec = mockSpec(3000, 1000);
 
         // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec);
 
         // then
-        assertThat(dto.isItemRequired()).isFalse();
+        assertThat(dto.getTotalRequiredExp()).isEqualTo(3000);
+        assertThat(dto.getRecyclingExpLimit()).isEqualTo(1000);
     }
 
     private LevelSpec mockSpec(int requiredExp, int recyclingExpLimit) {
@@ -31,78 +30,5 @@ class NextLevelConditionDtoTest {
         given(spec.getRequiredExp()).willReturn(requiredExp);
         given(spec.getRecyclingContributionExpLimit()).willReturn(recyclingExpLimit);
         return spec;
-    }
-
-    private MemberIsland mockIsland(int cumulativeExp, int recyclingContributionExp) {
-        MemberIsland island = mock(MemberIsland.class);
-        given(island.getCumulativeExp()).willReturn(cumulativeExp);
-        given(island.getRecyclingContributionExp()).willReturn(recyclingContributionExp);
-        return island;
-    }
-
-    @Test
-    void from_레벨2_진입직후_itemRequired가_false다() {
-        // given
-        LevelSpec spec = mockSpec(1500, 1000);
-        MemberIsland island = mockIsland(500, 0);
-
-        // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
-
-        // then
-        assertThat(dto.isItemRequired()).isFalse();
-    }
-
-    @Test
-    void from_레벨3_진입직후_itemRequired가_true다() {
-        // given
-        LevelSpec spec = mockSpec(3000, 1000);
-        MemberIsland island = mockIsland(1500, 0);
-
-        // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
-
-        // then
-        assertThat(dto.isItemRequired()).isTrue();
-    }
-
-    @Test
-    void from_분리배출_한도_소진_시_itemRequired가_true다() {
-        // given
-        LevelSpec spec = mockSpec(3000, 1000);
-        MemberIsland island = mockIsland(2300, 1000);
-
-        // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
-
-        // then
-        assertThat(dto.isItemRequired()).isTrue();
-    }
-
-    @Test
-    void from_아이템_선구매로_남은exp가_분리배출가능량보다_적으면_itemRequired가_false다() {
-        // given
-        LevelSpec spec = mockSpec(3000, 1000);
-        MemberIsland island = mockIsland(2800, 0);
-
-        // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
-
-        // then
-        assertThat(dto.isItemRequired()).isFalse();
-    }
-
-    @Test
-    void from_totalRequiredExp와_recyclingExpLimit이_currentSpec_값으로_설정된다() {
-        // given
-        LevelSpec spec = mockSpec(3000, 1000);
-        MemberIsland island = mockIsland(1500, 0);
-
-        // when
-        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
-
-        // then
-        assertThat(dto.getTotalRequiredExp()).isEqualTo(3000);
-        assertThat(dto.getRecyclingExpLimit()).isEqualTo(1000);
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDtoTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/dto/NextLevelConditionDtoTest.java
@@ -1,0 +1,108 @@
+package store.sonyk9919.api.domain.island.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+
+@ExtendWith(MockitoExtension.class)
+class NextLevelConditionDtoTest {
+
+    @Test
+    void from_레벨1_초기상태_itemRequired가_false다() {
+        // given
+        LevelSpec spec = mockSpec(500, 500);
+        MemberIsland island = mockIsland(0, 0);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.isItemRequired()).isFalse();
+    }
+
+    private LevelSpec mockSpec(int requiredExp, int recyclingExpLimit) {
+        LevelSpec spec = mock(LevelSpec.class);
+        given(spec.getRequiredExp()).willReturn(requiredExp);
+        given(spec.getRecyclingContributionExpLimit()).willReturn(recyclingExpLimit);
+        return spec;
+    }
+
+    private MemberIsland mockIsland(int cumulativeExp, int recyclingContributionExp) {
+        MemberIsland island = mock(MemberIsland.class);
+        given(island.getCumulativeExp()).willReturn(cumulativeExp);
+        given(island.getRecyclingContributionExp()).willReturn(recyclingContributionExp);
+        return island;
+    }
+
+    @Test
+    void from_레벨2_진입직후_itemRequired가_false다() {
+        // given
+        LevelSpec spec = mockSpec(1500, 1000);
+        MemberIsland island = mockIsland(500, 0);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.isItemRequired()).isFalse();
+    }
+
+    @Test
+    void from_레벨3_진입직후_itemRequired가_true다() {
+        // given
+        LevelSpec spec = mockSpec(3000, 1000);
+        MemberIsland island = mockIsland(1500, 0);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.isItemRequired()).isTrue();
+    }
+
+    @Test
+    void from_분리배출_한도_소진_시_itemRequired가_true다() {
+        // given
+        LevelSpec spec = mockSpec(3000, 1000);
+        MemberIsland island = mockIsland(2300, 1000);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.isItemRequired()).isTrue();
+    }
+
+    @Test
+    void from_아이템_선구매로_남은exp가_분리배출가능량보다_적으면_itemRequired가_false다() {
+        // given
+        LevelSpec spec = mockSpec(3000, 1000);
+        MemberIsland island = mockIsland(2800, 0);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.isItemRequired()).isFalse();
+    }
+
+    @Test
+    void from_totalRequiredExp와_recyclingExpLimit이_currentSpec_값으로_설정된다() {
+        // given
+        LevelSpec spec = mockSpec(3000, 1000);
+        MemberIsland island = mockIsland(1500, 0);
+
+        // when
+        NextLevelConditionDto dto = NextLevelConditionDto.from(spec, island);
+
+        // then
+        assertThat(dto.getTotalRequiredExp()).isEqualTo(3000);
+        assertThat(dto.getRecyclingExpLimit()).isEqualTo(1000);
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceTest.java
@@ -36,13 +36,13 @@ class IslandLevelServiceTest {
 
     private MemberIsland island;
     private LevelSpec currentSpec;
-    private LevelSpec nextSpec;
+    private LevelSpec nextLevelSpec;
 
     @BeforeEach
     void setUp() {
         island = mock(MemberIsland.class);
         currentSpec = mock(LevelSpec.class);
-        nextSpec = mock(LevelSpec.class);
+        nextLevelSpec = mock(LevelSpec.class);
         given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
     }
 
@@ -68,8 +68,7 @@ class IslandLevelServiceTest {
         given(island.getLevel()).willReturn(1);
         given(levelSpecCache.get(1)).willReturn(currentSpec);
         given(island.isMaxLevel()).willReturn(false);
-        given(levelSpecCache.get(2)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(false);
+        given(island.canLevelUp(currentSpec)).willReturn(false);
         stubIslandDtoFields();
 
         // when
@@ -85,8 +84,8 @@ class IslandLevelServiceTest {
         // given
         given(island.getLevel()).willReturn(2);
         given(island.isMaxLevel()).willReturn(false);
-        given(levelSpecCache.get(3)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(false);
+        given(levelSpecCache.get(2)).willReturn(currentSpec);
+        given(island.canLevelUp(currentSpec)).willReturn(false);
         stubIslandDtoFields();
 
         // when
@@ -102,9 +101,9 @@ class IslandLevelServiceTest {
         // given
         given(island.getLevel()).willReturn(1, 1, 2, 2);
         given(levelSpecCache.get(1)).willReturn(currentSpec);
+        given(levelSpecCache.get(2)).willReturn(nextLevelSpec);
         given(island.isMaxLevel()).willReturn(false, false);
-        given(levelSpecCache.get(2)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(true);
+        given(island.canLevelUp(currentSpec)).willReturn(true);
         stubIslandDtoFields();
 
         Item unlockedItem = createItem("해금아이템", 2);
@@ -126,6 +125,85 @@ class IslandLevelServiceTest {
                 .extracting(BuildingCatalogDto::getName).containsExactly("해금건물");
     }
 
+    @Test
+    void addRecyclingExp_해당_레벨에_해금_콘텐츠_없으면_빈_목록을_반환한다() throws Exception {
+        // given
+        given(island.getLevel()).willReturn(1, 1, 2, 2);
+        given(levelSpecCache.get(1)).willReturn(currentSpec);
+        given(levelSpecCache.get(2)).willReturn(nextLevelSpec);
+        given(island.isMaxLevel()).willReturn(false, false);
+        given(island.canLevelUp(currentSpec)).willReturn(true);
+        stubIslandDtoFields();
+        given(itemCache.getAll()).willReturn(List.of(createItem("아이템", 3)));
+        given(buildingMetadataCache.get()).willReturn(List.of(createBuilding("건물", 3)));
+
+        // when
+        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
+
+        // then
+        assertThat(result.getIsland()).isNotNull();
+        assertThat(result.getNotice().getUnlockedItems()).isEmpty();
+        assertThat(result.getNotice().getUnlockedBuildings()).isEmpty();
+    }
+
+    @Test
+    void addRecyclingExp_최종_레벨_도달_시_reachedMaxLevel이_true다() {
+        // given
+        given(island.getLevel()).willReturn(6, 6, 7);
+        given(levelSpecCache.get(6)).willReturn(currentSpec);
+        given(island.isMaxLevel()).willReturn(false, true);
+        given(island.canLevelUp(currentSpec)).willReturn(true);
+        stubIslandDtoFields();
+
+        // when
+        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
+
+        // then
+        assertThat(result.getIsland().getLevel()).isEqualTo(7);
+        assertThat(result.getNotice().isReachedMaxLevel()).isTrue();
+    }
+
+    @Test
+    void addRecyclingExp_최종_레벨_미달_시_reachedMaxLevel이_false다() {
+        // given
+        given(island.getLevel()).willReturn(1, 1, 2, 2);
+        given(levelSpecCache.get(1)).willReturn(currentSpec);
+        given(levelSpecCache.get(2)).willReturn(nextLevelSpec);
+        given(island.isMaxLevel()).willReturn(false, false);
+        given(island.canLevelUp(currentSpec)).willReturn(true);
+        stubIslandDtoFields();
+        given(itemCache.getAll()).willReturn(List.of());
+        given(buildingMetadataCache.get()).willReturn(List.of());
+
+        // when
+        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
+
+        // then
+        assertThat(result.getNotice().isReachedMaxLevel()).isFalse();
+    }
+
+    @Test
+    void addItemExp_레벨업_발생_시_새_레벨과_해금_목록을_반환한다() throws Exception {
+        // given
+        given(island.getLevel()).willReturn(2, 3, 3);
+        given(island.isMaxLevel()).willReturn(false, false);
+        given(levelSpecCache.get(2)).willReturn(currentSpec);
+        given(levelSpecCache.get(3)).willReturn(nextLevelSpec);
+        given(island.canLevelUp(currentSpec)).willReturn(true);
+        stubIslandDtoFields();
+        given(itemCache.getAll()).willReturn(List.of(createItem("레벨3아이템", 3)));
+        given(buildingMetadataCache.get()).willReturn(List.of(createBuilding("레벨3건물", 3)));
+
+        // when
+        LevelUpResult result = islandLevelService.addItemExp(MEMBER_ID, 250);
+
+        // then
+        assertThat(result.getIsland().getLevel()).isEqualTo(3);
+        assertThat(result.getNotice().getUnlockedItems())
+                .extracting(ItemCatalogDto::getName).containsExactly("레벨3아이템");
+        assertThat(result.getNotice().getUnlockedBuildings())
+                .extracting(BuildingCatalogDto::getName).containsExactly("레벨3건물");
+    }
 
     private void stubIslandDtoFields() {
         given(island.getNickname()).willReturn("테스트섬");
@@ -149,85 +227,5 @@ class IslandLevelServiceTest {
         );
         ctor.setAccessible(true);
         return ctor.newInstance(null, name, "PRODUCTION", "model", requiredLevel, 0, 0, 0);
-    }
-
-    @Test
-    void addRecyclingExp_해당_레벨에_해금_콘텐츠_없으면_빈_목록을_반환한다() throws Exception {
-        // given
-        given(island.getLevel()).willReturn(1, 1, 2, 2);
-        given(levelSpecCache.get(1)).willReturn(currentSpec);
-        given(island.isMaxLevel()).willReturn(false, false);
-        given(levelSpecCache.get(2)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(true);
-        stubIslandDtoFields();
-        given(itemCache.getAll()).willReturn(List.of(createItem("아이템", 3)));
-        given(buildingMetadataCache.get()).willReturn(List.of(createBuilding("건물", 3)));
-
-        // when
-        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
-
-        // then
-        assertThat(result.getIsland()).isNotNull();
-        assertThat(result.getNotice().getUnlockedItems()).isEmpty();
-        assertThat(result.getNotice().getUnlockedBuildings()).isEmpty();
-    }
-
-    @Test
-    void addRecyclingExp_최종_레벨_도달_시_reachedMaxLevel이_true다() {
-        // given
-        given(island.getLevel()).willReturn(6, 6, 7, 7);
-        given(levelSpecCache.get(6)).willReturn(currentSpec);
-        given(island.isMaxLevel()).willReturn(false, true);
-        given(levelSpecCache.get(7)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(true);
-        stubIslandDtoFields();
-
-        // when
-        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
-
-        // then
-        assertThat(result.getIsland().getLevel()).isEqualTo(7);
-        assertThat(result.getNotice().isReachedMaxLevel()).isTrue();
-    }
-
-    @Test
-    void addRecyclingExp_최종_레벨_미달_시_reachedMaxLevel이_false다() {
-        // given
-        given(island.getLevel()).willReturn(1, 1, 2, 2);
-        given(levelSpecCache.get(1)).willReturn(currentSpec);
-        given(island.isMaxLevel()).willReturn(false, false);
-        given(levelSpecCache.get(2)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(true);
-        stubIslandDtoFields();
-        given(itemCache.getAll()).willReturn(List.of());
-        given(buildingMetadataCache.get()).willReturn(List.of());
-
-        // when
-        LevelUpResult result = islandLevelService.addRecyclingExp(MEMBER_ID);
-
-        // then
-        assertThat(result.getNotice().isReachedMaxLevel()).isFalse();
-    }
-
-    @Test
-    void addItemExp_레벨업_발생_시_새_레벨과_해금_목록을_반환한다() throws Exception {
-        // given
-        given(island.getLevel()).willReturn(2, 3, 3);
-        given(island.isMaxLevel()).willReturn(false, false);
-        given(levelSpecCache.get(3)).willReturn(nextSpec);
-        given(island.canLevelUp(nextSpec)).willReturn(true);
-        stubIslandDtoFields();
-        given(itemCache.getAll()).willReturn(List.of(createItem("레벨3아이템", 3)));
-        given(buildingMetadataCache.get()).willReturn(List.of(createBuilding("레벨3건물", 3)));
-
-        // when
-        LevelUpResult result = islandLevelService.addItemExp(MEMBER_ID, 250);
-
-        // then
-        assertThat(result.getIsland().getLevel()).isEqualTo(3);
-        assertThat(result.getNotice().getUnlockedItems())
-                .extracting(ItemCatalogDto::getName).containsExactly("레벨3아이템");
-        assertThat(result.getNotice().getUnlockedBuildings())
-                .extracting(BuildingCatalogDto::getName).containsExactly("레벨3건물");
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
@@ -1,0 +1,107 @@
+package store.sonyk9919.api.domain.island.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import store.sonyk9919.api.domain.island.dto.MemberIslandDto;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.domain.member.service.MemberAccountService;
+import store.sonyk9919.api.domain.slot.service.SlotSetupService;
+
+@ExtendWith(MockitoExtension.class)
+class MemberIslandRegistryServiceTest {
+
+    @Mock private MemberIslandRepository memberIslandRepository;
+    @Mock private MemberAccountService memberAccountService;
+    @Mock private SlotSetupService slotSetupService;
+    @Mock private ResourceSetupService resourceSetupService;
+    @Mock private LevelSpecCache levelSpecCache;
+    @InjectMocks private MemberIslandRegistryService memberIslandRegistryService;
+
+    private static final Long MEMBER_ID = 1L;
+    private MemberIsland island;
+    private LevelSpec currentSpec;
+
+    @BeforeEach
+    void setUp() {
+        island = mock(MemberIsland.class);
+        currentSpec = mock(LevelSpec.class);
+        given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
+    }
+
+    @Test
+    void getIslandDto_최고레벨이_아닐_때_nextLevel이_포함된다() {
+        // given
+        given(island.isMaxLevel()).willReturn(false);
+        given(island.getLevel()).willReturn(2);
+        given(levelSpecCache.get(2)).willReturn(currentSpec);
+        given(currentSpec.getRequiredExp()).willReturn(1500);
+        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
+        given(island.getCumulativeExp()).willReturn(500);
+        given(island.getRecyclingContributionExp()).willReturn(0);
+
+        // when
+        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
+
+        // then
+        assertThat(dto.getNextLevel()).isNotNull();
+    }
+
+    @Test
+    void getIslandDto_최고레벨일_때_nextLevel이_null이다() {
+        // given
+        given(island.isMaxLevel()).willReturn(true);
+
+        // when
+        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
+
+        // then
+        assertThat(dto.getNextLevel()).isNull();
+    }
+
+    @Test
+    void getIslandDto_레벨3_진입직후_itemRequired가_true다() {
+        // given
+        given(island.isMaxLevel()).willReturn(false);
+        given(island.getLevel()).willReturn(3);
+        given(levelSpecCache.get(3)).willReturn(currentSpec);
+        given(currentSpec.getRequiredExp()).willReturn(3000);
+        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
+        given(island.getCumulativeExp()).willReturn(1500);
+        given(island.getRecyclingContributionExp()).willReturn(0);
+
+        // when
+        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
+
+        // then
+        assertThat(dto.getNextLevel().isItemRequired()).isTrue();
+    }
+
+    @Test
+    void getIslandDto_레벨2_진입직후_itemRequired가_false다() {
+        // given
+        given(island.isMaxLevel()).willReturn(false);
+        given(island.getLevel()).willReturn(2);
+        given(levelSpecCache.get(2)).willReturn(currentSpec);
+        given(currentSpec.getRequiredExp()).willReturn(1500);
+        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
+        given(island.getCumulativeExp()).willReturn(500);
+        given(island.getRecyclingContributionExp()).willReturn(0);
+
+        // when
+        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
+
+        // then
+        assertThat(dto.getNextLevel().isItemRequired()).isFalse();
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
@@ -45,10 +45,6 @@ class MemberIslandRegistryServiceTest {
         given(island.isMaxLevel()).willReturn(false);
         given(island.getLevel()).willReturn(2);
         given(levelSpecCache.get(2)).willReturn(currentSpec);
-        given(currentSpec.getRequiredExp()).willReturn(1500);
-        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
-        given(island.getCumulativeExp()).willReturn(500);
-        given(island.getRecyclingContributionExp()).willReturn(0);
 
         // when
         MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
@@ -67,41 +63,5 @@ class MemberIslandRegistryServiceTest {
 
         // then
         assertThat(dto.getNextLevel()).isNull();
-    }
-
-    @Test
-    void getIslandDto_레벨3_진입직후_itemRequired가_true다() {
-        // given
-        given(island.isMaxLevel()).willReturn(false);
-        given(island.getLevel()).willReturn(3);
-        given(levelSpecCache.get(3)).willReturn(currentSpec);
-        given(currentSpec.getRequiredExp()).willReturn(3000);
-        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
-        given(island.getCumulativeExp()).willReturn(1500);
-        given(island.getRecyclingContributionExp()).willReturn(0);
-
-        // when
-        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
-
-        // then
-        assertThat(dto.getNextLevel().isItemRequired()).isTrue();
-    }
-
-    @Test
-    void getIslandDto_레벨2_진입직후_itemRequired가_false다() {
-        // given
-        given(island.isMaxLevel()).willReturn(false);
-        given(island.getLevel()).willReturn(2);
-        given(levelSpecCache.get(2)).willReturn(currentSpec);
-        given(currentSpec.getRequiredExp()).willReturn(1500);
-        given(currentSpec.getRecyclingContributionExpLimit()).willReturn(1000);
-        given(island.getCumulativeExp()).willReturn(500);
-        given(island.getRecyclingContributionExp()).willReturn(0);
-
-        // when
-        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
-
-        // then
-        assertThat(dto.getNextLevel().isItemRequired()).isFalse();
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -259,7 +259,7 @@ class ShopServiceTest {
         given(mockIsland.getCumulativeExp()).willReturn(0);
         given(mockIsland.getRecyclingContributionExp()).willReturn(0);
         given(mockIsland.getItemContributionExp()).willReturn(0);
-        return MemberIslandDto.from(mockIsland);
+        return MemberIslandDto.from(mockIsland, null);
     }
 
     @Test


### PR DESCRIPTION
## 주요 변경사항

- `GET /v1/islands` 응답에 `nextLevel` 필드 추가
- "현재 레벨업을 위해 `아이템 기여 exp`가 필요한지 여부"(`itemRequired`)를 서버에서 계산하여 제공

### Feature

- `MemberIslandDto`에 `nextLevel: NextLevelConditionDto` 필드 추가
- `NextLevelConditionDto` 신규 생성 (`totalRequiredExp` = , `recyclingExpLimit`, `itemRequired`)
- 최고 레벨(7) 도달 시 `nextLevel: null` 반환

### Fix

- `canLevelUp` 기준 스펙을 `nextSpec → currentSpec`으로 수정
  - 기존 코드는 **다음 레벨** 스펙의 `requiredExp`를 참조하여 레벨업 조건이 잘못 계산됨
  - `currentSpec.requiredExp` 기준으로 변경하여 레벨 1 -> 2, 2 -> 3의 경우 분리배출만으로 레벨업 가능하도록 수정
  
### Test
- `NextLevelConditionDtoTest` 추가: `itemRequired` 경계 조건 포함 6개 케이스
- `MemberIslandRegistryServiceTest` 추가: 최고 레벨 여부 및 `itemRequired` 검증 4개 케이스

## 상세 설명

### nextLevel 응답 구조
```json
{
  "nextLevel": {
    "totalRequiredExp": 1500,
    "recyclingExpLimit": 1000,
    "itemRequired": false
  }
}
```
- `totalRequiredExp`: 다음 레벨까지 필요한 누적 경험치
- `recyclingExpLimit`: 현재 레벨에서 분리배출로 쌓을 수 있는 최대 경험치
- `itemRequired`: 현재 레벨업을 위해 `아이템 기여 exp`가 필요한지 여부

**[`itemRequired` 판단 기준]**

상황 | itemRequired
-- | --
레벨 1·2 (분리배출만으로 레벨업 가능한 구간) | false
레벨 3 이상 진입 직후 | true
레벨 3 이상이지만 아이템을 충분히 구매해 남은 exp를 분리배출로 커버 가능한 상태 | false
현재 레벨 분리배출 한도 소진 | true


## 참고사항
 
CLOSES #74 

### 여러 시나리오에 따른 응답값 구조 예시

**[레벨 3 이전]**

- 레벨 1, 초기 상태
```json
{
  "nickname": "수달이의 섬",
  "level": 1,
  "cumulativeExp": 0,
  "recyclingContributionExp": 0,
  "itemContributionExp": 0,
  "nextLevel": {
    "totalRequiredExp": 500,
    "recyclingExpLimit": 500,
    "itemRequired": false
  }
}
```

- 레벨 1, 분리배출 3회 완료
```json
{
  "nickname": "수달이의 섬",
  "level": 1,
  "cumulativeExp": 300,
  "recyclingContributionExp": 300,
  "itemContributionExp": 0,
  "nextLevel": {
    "totalRequiredExp": 500,
    "recyclingExpLimit": 500,
    "itemRequired": false
  }
}

```

- 레벨 2, 진입 직후
```json
{
  "nickname": "수달이의 섬",
  "level": 2,
  "cumulativeExp": 500,
  "recyclingContributionExp": 0,
  "itemContributionExp": 0,
  "nextLevel": {
    "totalRequiredExp": 1500,
    "recyclingExpLimit": 1000,
    "itemRequired": false
  }
}
```

- 레벨 2, 분리배출 4회 완료
```json
{
  "nickname": "수달이의 섬",
  "level": 2,
  "cumulativeExp": 900,
  "recyclingContributionExp": 400,
  "itemContributionExp": 0,
  "nextLevel": {
    "totalRequiredExp": 1500,
    "recyclingExpLimit": 1000,
    "itemRequired": false
  }
}
```

**[레벨 3 이후]**

- 레벨 3, 진입 직후
```json
{
  "nickname": "수달이의 섬",
  "level": 3,
  "cumulativeExp": 1500,
  "recyclingContributionExp": 0,
  "itemContributionExp": 0,
  "nextLevel": {
    "totalRequiredExp": 3000,
    "recyclingExpLimit": 1000,
    "itemRequired": true    // 남은분리배출(1000) < 남은필요(1500)
  }
}
```

- 레벨 3, 분리배출 한도 소진 + 아이템 진행 중
```json
{
  "nickname": "수달이의 섬",
  "level": 3,
  "cumulativeExp": 2300,
  "recyclingContributionExp": 1000,
  "itemContributionExp": 800,
  "nextLevel": {
    "totalRequiredExp": 3000,
    "recyclingExpLimit": 1000,
    "itemRequired": true    // 남은분리배출(0) < 남은필요(700)
  }
}
```

- 레벨 3, 아이템만으로 진행해 레벨업 목전
```json
{
  "nickname": "수달이의 섬",
  "level": 3,
  "cumulativeExp": 2800,
  "recyclingContributionExp": 0,
  "itemContributionExp": 1300,
  "nextLevel": {
    "totalRequiredExp": 3000,
    "recyclingExpLimit": 1000,
    "itemRequired": false   // 남은분리배출(1000) >= 남은필요(200) — 분리배출만으로도 가능해진 상태
  }
}
```

- 최고 레벨 (레벨 7)
```json
{
  "nickname": "수달이의 섬",
  "level": 7,
  "cumulativeExp": 11250,
  "recyclingContributionExp": 800,
  "itemContributionExp": 200,
  "nextLevel": null
}
```

---

우선 이슈에 올려주신 UI 참고해 nextLevel 필드를 구성해봤는데, 혹시 `다음 레벨까지 필요한 누적 경험치`(=`totalRequiredExp`) 대신
`다음 레벨까지 더 쌓아야 하는 경험치량` 필드가 있는 게 더 편할 것 같다 하시면 말씀해주세요!
