### PR TITLE
fix: 카카오 로그인 동시 요청 시 중복 회원 가입 되는 문제

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
+++ b/src/main/java/store/sonyk9919/api/domain/auth/service/AuthLoginFacade.java
@@ -24,12 +24,7 @@ public class AuthLoginFacade {
     public List<TokenResponseDto> login(OAuthProviderType type, String code) {
         OAuthProvider provider = oAuthProviderFactory.getProvider(type);
         OAuthUserInfoDto userInfo = provider.getUserInfo(code);
-        try {
-            MemberAccount memberAccount = memberAccountService.getMemberAccount(userInfo, type);
-            return authTokenIssuer.issue(AuthMemberDto.from(memberAccount));
-        } catch (CustomException e) {
-            MemberAccount memberAccount = memberAccountService.createMemberAccount(userInfo, type);
-            return authTokenIssuer.issue(AuthMemberDto.from(memberAccount));
-        }
+        MemberAccount memberAccount = memberAccountService.findOrCreateMemberAccount(userInfo, type);
+        return authTokenIssuer.issue(AuthMemberDto.from(memberAccount));
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/member/entity/MemberAccount.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/entity/MemberAccount.java
@@ -15,6 +15,11 @@ import store.sonyk9919.api.global.common.exception.CustomException;
 @Getter
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames =  { "provider_id", "provider_type" })
+        }
+)
 public class MemberAccount {
 
     @Id

--- a/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
+++ b/src/main/java/store/sonyk9919/api/domain/member/service/MemberAccountService.java
@@ -1,6 +1,7 @@
 package store.sonyk9919.api.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.auth.dto.OAuthUserInfoDto;
@@ -24,14 +25,22 @@ public class MemberAccountService {
     }
 
     @Transactional
-    public MemberAccount createMemberAccount(OAuthUserInfoDto userInfo, OAuthProviderType type) {
+    public MemberAccount findOrCreateMemberAccount(OAuthUserInfoDto userInfo, OAuthProviderType type) {
+        return memberAccountRepository.findByProviderIdAndType(userInfo.getId(), type)
+                .orElseGet(() -> {
+                    try {
+                        return createMemberAccount(userInfo, type);
+                    } catch (DataIntegrityViolationException e) {
+                        return memberAccountRepository
+                                .findByProviderIdAndType(userInfo.getId(), type)
+                                .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_BAD_REQUEST));
+                    }
+                });
+    }
+
+    private MemberAccount createMemberAccount(OAuthUserInfoDto userInfo, OAuthProviderType type) {
         MemberAccount memberAccount = MemberAccount.from(userInfo, type, AccountRole.USER);
         memberAccountRepository.save(memberAccount);
         return memberAccount;
-    }
-
-    public MemberAccount getMemberAccount(OAuthUserInfoDto userInfo, OAuthProviderType type) {
-        return memberAccountRepository.findByProviderIdAndType(userInfo.getId(), type)
-                .orElseThrow(() -> new CustomException(MemberStatus.MEMBER_ACCOUNT_BAD_REQUEST));
     }
 }


### PR DESCRIPTION
## 주요 변경사항

### Fix
- 카카오 첫 로그인 동시요청 시 중복 회원 가입 되는 문제 

## 상세 설명

- 첫 로그인 일 때, 동시 요청하는 경우 중복 회원 가입되는 문제가 있었습니다.
- 따라서 테이블에 [provider_id, provider_type]쌍으로 유니크 제약조건을 추가하였습니다.

## 참고사항

X
