### PR TITLE
feat: 아이템 사용량 조회 API 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
@@ -10,9 +10,13 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
+import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
 import store.sonyk9919.api.domain.island.dto.MemberIslandCreateRequestDto;
 import store.sonyk9919.api.domain.island.dto.MemberIslandDto;
+import store.sonyk9919.api.domain.island.service.ItemUsageService;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/v1/islands")
@@ -20,6 +24,7 @@ import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 public class MemberIslandController {
 
     private final MemberIslandRegistryService memberIslandRegistryService;
+    private final ItemUsageService itemUsageService;
 
     @Operation(summary = "섬 생성", description = "인증된 회원의 새로운 섬을 생성합니다.")
     @ApiResponses(value = {
@@ -48,5 +53,19 @@ public class MemberIslandController {
             @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
     ) {
         return memberIslandRegistryService.getIslandDto(authMember.getId());
+    }
+
+    @Operation(summary = "아이템 사용량 조회", description = "회원의 섬에서 아이템별 현재 사용량을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "섬을 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/items/usages")
+    @ResponseStatus(HttpStatus.OK)
+    public List<ItemCatalogDto> getItemUsages(
+            @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
+    ) {
+        return itemUsageService.getItemUsages(authMember.getId());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/dto/ItemCatalogDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/ItemCatalogDto.java
@@ -18,16 +18,16 @@ public class ItemCatalogDto {
     private final int expReward;
     private final boolean purchasable;
 
-    public static ItemCatalogDto from(Item item) {
+    public static ItemCatalogDto from(Item item, long currentCount, boolean purchasable) {
         return new ItemCatalogDto(
                 item.getId(),
                 item.getName(),
                 item.getPrice(),
                 item.getMaxCount(),
-                0L,
+                currentCount,
                 item.getUnlockLevel(),
                 item.getExpReward(),
-                true
+                purchasable
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/repository/IslandItemUsageRepository.java
@@ -3,6 +3,8 @@ package store.sonyk9919.api.domain.island.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
@@ -12,4 +14,7 @@ public interface IslandItemUsageRepository extends JpaRepository<IslandItemUsage
     Optional<IslandItemUsage> findByIslandAndItem(MemberIsland island, Item item);
 
     List<IslandItemUsage> findAllByIsland(MemberIsland island);
+
+    @Query("SELECT u.item.id, u.useCount FROM IslandItemUsage u WHERE u.island = :island")
+    List<Object[]> findItemIdAndUseCountByIsland(@Param("island") MemberIsland island);
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -80,7 +80,7 @@ public class IslandLevelService {
     private List<ItemCatalogDto> getUnlockedItems(int newLevel) {
         return itemCache.getAll().stream()
                 .filter(i -> i.getUnlockLevel() == newLevel)
-                .map(ItemCatalogDto::from)
+                .map(i -> ItemCatalogDto.from(i, 0L, true))
                 .toList();
     }
 

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
@@ -1,0 +1,51 @@
+package store.sonyk9919.api.domain.island.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.exception.IslandStatus;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemUsageService {
+
+    private final MemberIslandRepository memberIslandRepository;
+    private final IslandItemUsageRepository islandItemUsageRepository;
+    private final ItemCache itemCache;
+
+    public List<ItemCatalogDto> getItemUsages(Long memberAccountId) {
+        MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
+                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
+        List<Item> items = itemCache.getAll();
+        Map<Long, Long> usageByItemId = buildUsageMap(island);
+        return items.stream()
+                .map(item -> toItemCatalogDto(item, usageByItemId, island))
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, Long> buildUsageMap(MemberIsland island) {
+        return islandItemUsageRepository.findItemIdAndUseCountByIsland(island).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+    }
+
+    private ItemCatalogDto toItemCatalogDto(Item item, Map<Long, Long> usageByItemId, MemberIsland island) {
+        long currentCount = usageByItemId.getOrDefault(item.getId(), 0L);
+        boolean purchasable = island.getLevel() >= item.getUnlockLevel()
+                && currentCount < item.getMaxCount();
+        return ItemCatalogDto.from(item, currentCount, purchasable);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
@@ -6,10 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
 import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
-import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
-import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
-import store.sonyk9919.api.global.common.exception.CustomException;
 
 import java.util.List;
 import java.util.Map;
@@ -20,13 +17,12 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ItemUsageService {
 
-    private final MemberIslandRepository memberIslandRepository;
+    private final MemberIslandRegistryService memberIslandRegistryService;
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final ItemCache itemCache;
 
     public List<ItemCatalogDto> getItemUsages(Long memberAccountId) {
-        MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
-                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
+        MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
         List<Item> items = itemCache.getAll();
         Map<Long, Long> usageByItemId = buildUsageMap(island);
         return items.stream()

--- a/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
@@ -1,0 +1,173 @@
+package store.sonyk9919.api.domain.island.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.exception.IslandStatus;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class ItemUsageServiceTest {
+
+    @Mock private MemberIslandRepository memberIslandRepository;
+    @Mock private IslandItemUsageRepository islandItemUsageRepository;
+    @Mock private ItemCache itemCache;
+    @InjectMocks private ItemUsageService itemUsageService;
+
+    private static final Long MEMBER_ID = 1L;
+    private List<Item> allItems;
+    private Item targetItem;
+    private MemberIsland island;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        targetItem = createItem(1L, "쓰레기 제거 (소)", 100, 2, 3, 250);
+        allItems = List.of(
+                targetItem,
+                createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
+                createItem(3L, "토양 정화",       50,  8, 3, 125),
+                createItem(4L, "수질 개선",       50, 10, 3, 125),
+                createItem(5L, "나무 심기",       30, 20, 3, 75)
+        );
+        island = mock(MemberIsland.class);
+        given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
+    }
+
+    private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
+            throws Exception {
+        Constructor<Item> ctor = Item.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Item item = ctor.newInstance();
+        ReflectionTestUtils.setField(item, "id", id);
+        ReflectionTestUtils.setField(item, "name", name);
+        ReflectionTestUtils.setField(item, "price", price);
+        ReflectionTestUtils.setField(item, "maxCount", maxCount);
+        ReflectionTestUtils.setField(item, "unlockLevel", unlockLevel);
+        ReflectionTestUtils.setField(item, "expReward", expReward);
+        return item;
+    }
+
+    @Test
+    void getItemUsages_아이템_5개를_반환한다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        assertThat(result).hasSize(5);
+    }
+
+    @Test
+    void getItemUsages_사용_이력_없으면_currentCount가_0이다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        assertThat(result).allMatch(r -> r.getCurrentCount() == 0);
+    }
+
+    @Test
+    void getItemUsages_사용_이력_있으면_currentCount가_반영된다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island))
+                .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 1L)));
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        ItemCatalogDto response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.getCurrentCount()).isEqualTo(1L);
+    }
+
+    private Object[] usageRow(Long itemId, long useCount) {
+        return new Object[]{itemId, useCount};
+    }
+
+    @Test
+    void getItemUsages_레벨_미달_시_purchasable이_false다() {
+        // given
+        given(island.getLevel()).willReturn(2);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        assertThat(result).allMatch(r -> !r.isPurchasable());
+    }
+
+    @Test
+    void getItemUsages_레벨_충족_시_purchasable이_true다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        assertThat(result).allMatch(ItemCatalogDto::isPurchasable);
+    }
+
+    @Test
+    void getItemUsages_maxCount_도달_시_purchasable이_false다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(itemCache.getAll()).willReturn(allItems);
+        given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island))
+                .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 2L)));
+
+        // when
+        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+
+        // then
+        ItemCatalogDto response = result.stream()
+                .filter(r -> r.getItemId().equals(targetItem.getId()))
+                .findFirst().orElseThrow();
+        assertThat(response.isPurchasable()).isFalse();
+    }
+
+    @Test
+    void getItemUsages_섬이_없으면_예외가_발생한다() {
+        // given
+        given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> itemUsageService.getItemUsages(MEMBER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(IslandStatus.NOT_FOUND_ISLAND.getMessage());
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,13 +19,12 @@ import store.sonyk9919.api.domain.island.entity.Item;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
-import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
 import store.sonyk9919.api.global.common.exception.CustomException;
 
 @ExtendWith(MockitoExtension.class)
 class ItemUsageServiceTest {
 
-    @Mock private MemberIslandRepository memberIslandRepository;
+    @Mock private MemberIslandRegistryService memberIslandRegistryService;
     @Mock private IslandItemUsageRepository islandItemUsageRepository;
     @Mock private ItemCache itemCache;
     @InjectMocks private ItemUsageService itemUsageService;
@@ -47,7 +45,7 @@ class ItemUsageServiceTest {
                 createItem(5L, "나무 심기",       30, 20, 3, 75)
         );
         island = mock(MemberIsland.class);
-        given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
+        given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
     }
 
     private Item createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
@@ -163,7 +161,8 @@ class ItemUsageServiceTest {
     @Test
     void getItemUsages_섬이_없으면_예외가_발생한다() {
         // given
-        given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.empty());
+        given(memberIslandRegistryService.getIsland(MEMBER_ID))
+                .willThrow(new CustomException(IslandStatus.NOT_FOUND_ISLAND));
 
         // when & then
         assertThatThrownBy(() -> itemUsageService.getItemUsages(MEMBER_ID))


### PR DESCRIPTION
## 주요 변경사항

- 사용자의 섬에서 아이템별 현재 사용량을 조회하는 API를 추가했습니다.

### Feature
- `GET /v1/islands/items/usages` 엔드포인트 추가
- `ItemUsageService` 신규 추가: 아이템 전체 목록과 실제 사용량을 조합하여 반환
- `IslandItemUsageRepository.findItemIdAndUseCountByIsland()` 추가: N+1 방지를 위해 `item_id`, `use_count`만 조회하는 JPQL 쿼리

### Refactor
- `ItemCatalogDto.from()` 시그니처를 `from(Item, long, boolean)`으로 통일
  - 기존 하드코딩(`currentCount=0`, `purchasable=true`) 제거
  
### Test
- `ItemUsageServiceTest` 추가 (7개 케이스)

## 상세 설명

- 사용 이력이 없는 아이템은 `currentCount=0`으로 응답에 포함됩니다.
- `purchasable`은 섬 레벨과 현재 사용량을 기준으로 서비스에서 계산합니다.
- `IslandItemUsage.item`이 LAZY 로딩이라 기존 `findAllByIsland()` 사용 시 N+1이 발생하므로, `item_id`와 `use_count`만 직접 조회하는 쿼리로 대체했습니다.

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-479?atlOrigin=eyJpIjoiYWYxYTBjMjBjNDZmNDViNjgzZjdhNjMyYzU4OTgzNDYiLCJwIjoiaiJ9

## 참고사항

`GET /v1/shops/items`에서 받는 응답값과 동일한 형태로 
```json
[
  {
    "itemId": 0,
    "name": "string",
    "price": 0,
    "maxCount": 0,
    "currentCount": 0,
    "unlockLevel": 0,
    "expReward": 0,
    "purchasable": true
  }
]
```
만들었습니다! (전에 레벨업 시 해금된 아이템 결과 반환 시에도 이렇게 요청주셨던 것 같아 더 용이하실까해서욥)

변경 필요한 부분 있으시면 말씀부탁드립니다!!