### PR TITLE
fix: Harvest 응답 구조 변경 및 연료 주입 시 발생하는 문제

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/building/controller/BuildingHarvestController.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/controller/BuildingHarvestController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
 import store.sonyk9919.api.domain.building.dto.BuildingResponseDto;
+import store.sonyk9919.api.domain.building.dto.HarvestPreviewResponseDto;
 import store.sonyk9919.api.domain.building.dto.HarvestResponseDto;
 import store.sonyk9919.api.domain.building.dto.OperationPreviewDto;
 import store.sonyk9919.api.domain.building.service.BuildingHarvestService;
@@ -86,7 +87,7 @@ public class BuildingHarvestController {
             @ApiResponse(responseCode = "404", description = "슬롯 없음 / 건물 없음")
     })
     @GetMapping("/harvest")
-    public HarvestResponseDto previewHarvest(
+    public HarvestPreviewResponseDto previewHarvest(
             @AuthMember AuthMemberDto authMember,
             @PathVariable Integer slotNumber
     ) {

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/HarvestPreviewResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/HarvestPreviewResponseDto.java
@@ -1,0 +1,16 @@
+package store.sonyk9919.api.domain.building.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class HarvestPreviewResponseDto {
+
+    private int gem;
+
+    public static HarvestPreviewResponseDto from(int expectedGem) {
+        return new HarvestPreviewResponseDto(expectedGem);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/building/dto/HarvestResponseDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/HarvestResponseDto.java
@@ -1,16 +1,51 @@
 package store.sonyk9919.api.domain.building.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class HarvestResponseDto {
 
-    private int gems;
+    @JsonInclude(JsonInclude.Include.NON_NULL) private BuildingState building;
+    private IslandResource resource;
+    private List<SlotResponseDto> slots;
 
-    public static HarvestResponseDto from(int expectedGems){
-        return new HarvestResponseDto(expectedGems);
+    private HarvestResponseDto(BuildingState building, IslandResource resource, List<SlotResponseDto> slots) {
+        this.building = building;
+        this.resource = resource;
+        this.slots = slots;
+    }
+
+    public static HarvestResponseDto from(int remainingGem, MemberResource islandGem, SlotResponseDto slot) {
+        return new HarvestResponseDto(BuildingState.of(remainingGem), IslandResource.of(islandGem), List.of(slot));
+    }
+
+    public static HarvestResponseDto from(MemberResource islandGem, List<SlotResponseDto> slots) {
+        return new HarvestResponseDto(null, IslandResource.of(islandGem), slots);
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class BuildingState {
+        private final long gem;
+
+        public static BuildingState of(long remainingGems) {
+            return new BuildingState(remainingGems);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class IslandResource {
+        private final long gem;
+
+        public static IslandResource of(MemberResource gem) {
+            return new IslandResource(gem.getAmount());
+        }
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
@@ -5,13 +5,17 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.building.dto.BuildingInfoDto;
+import store.sonyk9919.api.domain.building.dto.HarvestPreviewResponseDto;
 import store.sonyk9919.api.domain.building.dto.HarvestResponseDto;
 import store.sonyk9919.api.domain.building.entity.Building;
 import store.sonyk9919.api.domain.building.exception.BuildingStatus;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
 import store.sonyk9919.api.domain.island.entity.ResourceType;
 import store.sonyk9919.api.domain.island.service.MemberIslandRegistryService;
 import store.sonyk9919.api.domain.island.service.ResourceService;
+import store.sonyk9919.api.domain.slot.dto.SlotResponseDto;
 import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.domain.slot.service.SlotQueryHelper;
@@ -37,22 +41,20 @@ public class BuildingHarvestService {
         if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
         Building building = slot.getBuilding();
 
+        double boostPercent = islandBoostCache.getTotalBoost(island);
         HarvestCalculator calculator = HarvestCalculator.from(building);
-        int gems = computeGems(island, calculator);
+        int gems = calculator.calculate(boostPercent);
         if (gems <= 0) throw new CustomException(BuildingStatus.NOTHING_TO_HARVEST);
 
-        applyHarvest(building, island, gems, calculator);
-        return HarvestResponseDto.from(gems);
+        MemberResource islandGem = applyHarvest(building, island, gems, calculator);
+        int remainingGem = HarvestCalculator.from(building).calculate(boostPercent);
+        SlotResponseDto slotDto = SlotResponseDto.of(slot, BuildingInfoDto.of(building, building.getBuildingMetadata()));
+        return HarvestResponseDto.from(remainingGem, islandGem, slotDto);
     }
 
-    private int computeGems(MemberIsland island, HarvestCalculator calculator) {
-        double boostPercent = islandBoostCache.getTotalBoost(island);
-        return calculator.calculate(boostPercent);
-    }
-
-    private void applyHarvest(Building building, MemberIsland island, int gems, HarvestCalculator calculator) {
+    private MemberResource applyHarvest(Building building, MemberIsland island, int gems, HarvestCalculator calculator) {
         building.updateCollectedTime(calculator.getBaseTime());
-        resourceService.add(island, ResourceType.GEM, gems);
+        return resourceService.add(island, ResourceType.GEM, gems);
     }
 
     @DistributedLock(key = "'island:' + #memberId + ':harvest'")
@@ -66,8 +68,11 @@ public class BuildingHarvestService {
         int totalGems = applyAndSumGems(harvestableSlots, boostPercent);
         if (totalGems <= 0) throw new CustomException(BuildingStatus.NOTHING_TO_HARVEST);
 
-        resourceService.add(island, ResourceType.GEM, totalGems);
-        return HarvestResponseDto.from(totalGems);
+        MemberResource gem = resourceService.add(island, ResourceType.GEM, totalGems);
+        List<SlotResponseDto> slotDtos = harvestableSlots.stream()
+                .map(slot -> SlotResponseDto.of(slot, BuildingInfoDto.of(slot.getBuilding(), slot.getBuilding().getBuildingMetadata())))
+                .collect(Collectors.toList());
+        return HarvestResponseDto.from(gem, slotDtos);
     }
 
     private List<Slot> getHarvestableSlots(MemberIsland island) {
@@ -90,7 +95,7 @@ public class BuildingHarvestService {
     }
 
     @Transactional(readOnly = true)
-    public HarvestResponseDto preview(Long memberId, Integer slotNumber) {
+    public HarvestPreviewResponseDto preview(Long memberId, Integer slotNumber) {
         Slot slot = slotQueryHelper.getSlot(memberId, slotNumber);
 
         if (!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
@@ -100,6 +105,6 @@ public class BuildingHarvestService {
         int expectedGems = HarvestCalculator.from(building)
                 .calculate(totalBoost);
 
-        return HarvestResponseDto.from(expectedGems);
+        return HarvestPreviewResponseDto.from(expectedGems);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
@@ -3,9 +3,11 @@ package store.sonyk9919.api.domain.building.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.building.dto.BuildingInfoDto;
 import store.sonyk9919.api.domain.building.dto.BuildingResponseDto;
 import store.sonyk9919.api.domain.building.dto.OperationPreviewDto;
 import store.sonyk9919.api.domain.building.entity.Building;
+import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
 import store.sonyk9919.api.domain.building.entity.BuildingYield;
 import store.sonyk9919.api.domain.building.exception.BuildingStatus;
 import store.sonyk9919.api.domain.island.entity.ResourceType;
@@ -31,12 +33,12 @@ public class BuildingOperateService {
         if(!slot.hasBuilding()) throw new CustomException(BuildingStatus.BUILDING_NOT_FOUND);
         Building building = slot.getBuilding();
         BuildingYield yield = building.getCurrentYield();
+        BuildingMetadata buildingMetadata = building.getBuildingMetadata();
 
         building.operate(yield.getDurationSecond());
         resourceService.subtract(slot.getIsland(), ResourceType.FUEL, yield.getRequiredFuel());
-
         return BuildingResponseDto.of(
-                SlotResponseDto.from(slot),
+                SlotResponseDto.of(slot, BuildingInfoDto.of(building, buildingMetadata)),
                 resourceService.getBalance(memberId)
         );
     }


### PR DESCRIPTION
## 주요 변경사항

### Refactor

- 건물 수확시 아래와 같은 변경된 자원을 반환하도록 수정했습니다.
  - 수확 이후 변경된 사용자의 보석량
  - 수확 이후 건물이 생성한 보석량
  - 각 건물의 lastCollectedAt을 반영하기 위해 수확이 발생한 슬롯 정보

### Fix
- 연료 주입 시 반환하는 슬롯의 building이 null로 설정되는 문제를 해결하였습니다. 

## 참고사항

X