### PR TITLE
feat: 정적 데이터 미리 로딩 및 동적 데이터 ttl 설정

### DIFF
--- a/src/main/java/store/sonyk9919/api/global/cache/CacheWarmUpListener.java
+++ b/src/main/java/store/sonyk9919/api/global/cache/CacheWarmUpListener.java
@@ -1,0 +1,32 @@
+package store.sonyk9919.api.global.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.global.common.exception.CustomException;
+import store.sonyk9919.api.global.common.lock.LockStatus;
+
+@Slf4j
+@Profile("!test")
+@Component
+@RequiredArgsConstructor
+public class CacheWarmUpListener {
+
+    private final CacheWarmUpService cacheWarmUpService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        try {
+            cacheWarmUpService.warmUpStaticData();
+        } catch (CustomException e) {
+            if (e.getStatus() == LockStatus.LOCK_ACQUISITION_FAILED) {
+                log.info("다른 인스턴스에서 캐시 워밍업 수행 중입니다.");
+                return;
+            }
+            throw e;
+        }
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/cache/CacheWarmUpService.java
+++ b/src/main/java/store/sonyk9919/api/global/cache/CacheWarmUpService.java
@@ -1,0 +1,46 @@
+package store.sonyk9919.api.global.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import store.sonyk9919.api.domain.building.service.BuildingMetadataCache;
+import store.sonyk9919.api.domain.island.repository.LevelSpecRepository;
+import store.sonyk9919.api.domain.island.service.ItemCache;
+import store.sonyk9919.api.domain.island.service.LevelSpecCache;
+import store.sonyk9919.api.global.common.lock.DistributedLock;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CacheWarmUpService {
+
+    private final LevelSpecRepository levelSpecRepository;
+    private final LevelSpecCache levelSpecCache;
+    private final BuildingMetadataCache buildingMetadataCache;
+    private final ItemCache itemCache;
+
+    @DistributedLock(key = "'system:cache:warmup'", waitTime = 0, leaseTime = 30)
+    public void warmUpStaticData() {
+        log.info("[CacheWarmup] start");
+
+        warmUpBuildingMetadata();
+        warmUpLevelSpec();
+        warmUpItems();
+
+        log.info("[CacheWarmup] end");
+    }
+
+    private void warmUpBuildingMetadata() {
+        buildingMetadataCache.get();
+    }
+
+    private void warmUpLevelSpec() {
+        levelSpecRepository.findAll().forEach(
+                spec -> levelSpecCache.get(spec.getLevel())
+        );
+    }
+
+    private void warmUpItems() {
+        itemCache.getAll();
+    }
+}

--- a/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
+++ b/src/main/java/store/sonyk9919/api/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package store.sonyk9919.api.global.config;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
@@ -64,8 +67,23 @@ public class RedisConfig {
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+        RedisCacheConfiguration staticConfig = config.entryTtl(Duration.ZERO);
+        RedisCacheConfiguration dynamicConfig = config.entryTtl(Duration.ofDays(7));
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        cacheConfigurations.put("buildingCatalog", staticConfig);
+        cacheConfigurations.put("level-spec", staticConfig);
+        cacheConfigurations.put("items", staticConfig);
+
+        cacheConfigurations.put("islandBoost", dynamicConfig);
+        cacheConfigurations.put("islandQuizRewardBoost", dynamicConfig);
+        cacheConfigurations.put("islandQuizRewardAdd", dynamicConfig);
+
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
+                .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
     }
 

--- a/src/test/java/store/sonyk9919/api/global/cache/CacheWarmUpServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/global/cache/CacheWarmUpServiceTest.java
@@ -1,0 +1,54 @@
+package store.sonyk9919.api.global.cache;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import store.sonyk9919.api.domain.building.service.BuildingMetadataCache;
+import store.sonyk9919.api.domain.island.entity.LevelSpec;
+import store.sonyk9919.api.domain.island.repository.LevelSpecRepository;
+import store.sonyk9919.api.domain.island.service.ItemCache;
+import store.sonyk9919.api.domain.island.service.LevelSpecCache;
+
+@ExtendWith(MockitoExtension.class)
+class CacheWarmUpServiceTest {
+
+    @Mock private LevelSpecRepository levelSpecRepository;
+    @Mock private LevelSpecCache levelSpecCache;
+    @Mock private BuildingMetadataCache buildingMetadataCache;
+    @Mock private ItemCache itemCache;
+
+    @InjectMocks private CacheWarmUpService cacheWarmUpService;
+
+    @Test
+    @DisplayName("서버 시작 시 정적 데이터 캐시를 미리 로딩한다")
+    void warmUpStaticData() {
+
+        // given
+        LevelSpec level1 = mock(LevelSpec.class);
+        LevelSpec level2 = mock(LevelSpec.class);
+
+        given(level1.getLevel()).willReturn(1);
+        given(level2.getLevel()).willReturn(2);
+
+        given(levelSpecRepository.findAll()).willReturn(List.of(level1, level2));
+
+        // when
+        cacheWarmUpService.warmUpStaticData();
+
+        // then
+        then(buildingMetadataCache).should(times(1)).get();
+        then(levelSpecRepository).should(times(1)).findAll();
+        then(levelSpecCache).should(times(1)).get(1);
+        then(levelSpecCache).should(times(1)).get(2);
+        then(itemCache).should(times(1)).getAll();
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

### Feature
- 서버 기동 시 `BuildingMetadata`, `LevelSpec`, `Item` 정적 데이터를 Redis에 자동 로드
- RedisConfig 캐시별 ttl 설정 

### Test
- 서버 시작 시 각 캐시 메서드가 호출되는지 확인

## 상세 설명

- 기존에는 islandBoost 등 유저별 캐시에 TTL이 없어 장기 미접속 유저의 데이터가 Redis에 계속 적재되고 있었습니다. 그래서 RedisCacheManager에 캐시 이름별 설정을 분리하여 유저별 캐시는 7일 TTL을 적용했습니다. 
  - 건물 변경 이벤트 요청시  evict되는 기존 동작은 그대로 유지됩니다.


- BuildingMetadata, LevelSpec, Item은 서비스 운영 중 거의 변경되지 않는 정적 데이터도 최초 요청 시에 DB를 조회하는걸 서버 실행 시에 미리 로드하도록 추가했습니다.

## 체크리스트

- [x] redisManager에서 ttl 확인

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-

## 참고사항

- 정적 데이터 ttl 확인 (-1)
<img width="598" height="80" alt="image" src="https://github.com/user-attachments/assets/9c0a0921-70a7-46a0-a82b-69162d920b03" />

<img width="601" height="80" alt="image" src="https://github.com/user-attachments/assets/2e53deb0-bd50-4d29-8c11-73270355a563" />
<img width="592" height="68" alt="image" src="https://github.com/user-attachments/assets/32616c14-c795-47fa-baef-52401656c71f" />

- 유저별 데이터 (동적) ttl 확인 (7일)

<img width="955" height="65" alt="image" src="https://github.com/user-attachments/assets/1d428bd8-5c93-44bb-b00f-adf22df44bf5" />
<img width="955" height="74" alt="image" src="https://github.com/user-attachments/assets/9f4651b7-9131-49fb-b3a4-aa428a9728d3" />
<img width="960" height="57" alt="image" src="https://github.com/user-attachments/assets/0a3ecc14-a84d-45b0-889f-ff4ff25a9e34" />


<br/><br/>
- 테스트 환경 캐시 워밍업 비활성화 (`@Profile("!test")`)
  - 통합 테스트 환경 기동 시, Mock 처리된 `RedissonClient`가 분산 락 획득 과정에서 null을 반환해서 NPE랑 컨텍스트 로드가 실패하는 이슈가 있었습니다. 
  - 그래서 테스트 환경에서는 불필요한 초기화 로직이 동작하지 않도록 `CacheWarmUpListener`를 테스트 프로필에서 제외했습니다