### PR TITLE
fix: MemberIslandDto 생성자에 제외된 region 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
@@ -38,6 +38,7 @@ public class MemberIslandDto {
     ) {
         return new MemberIslandDto(
                 island.getNickname(),
+                island.getRegion(),
                 island.getLevel(),
                 island.getCumulativeExp(),
                 island.getRecyclingContributionExp(),


### PR DESCRIPTION
## 주요 변경사항

### Fix

MemberIslandDto.from에서 region을 추가하지 않아 테스트가 실패해서 fix합니다.
(브런치 충돌 없어서 병합했는데 develop pull을 제대로 못받은것 같습니다..)


## 참고사항
- 리뷰없이 병합하겠습니다!