### PR TITLE
fix: dev 환경 CORS 허용 메서드에 delete, put 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -81,6 +81,8 @@ security:
     methods:
       - GET
       - POST
+      - DELETE
+      - PUT
       - OPTIONS
     headers:
       - "*"


### PR DESCRIPTION
## 주요 변경사항

- application-dev.yml에 application-prod와 같이 delete와 put을 추가했습니다.

## 상세 설명

- 개발환경에서 건물 철거 시 application-dev.yml에 delete가 없어서 클라이언트에서 철거 실패 [http://localhost:3000/v1/slots/4/buildings 403 (Forbidden)]가 나서 prod와 동일하게 delete와 put을 추가했습니다.

## 체크리스트
- [x] 클라이언트에서 건물 철거 확인 

## 참고사항
- 크게 수정이 없어 리뷰 없이 병합하겠습니다!