### PR TITLE
feat: 섬 조회 API 응답에 3D 모델 URI 필드 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/MemberIslandDto.java
@@ -15,10 +15,11 @@ public class MemberIslandDto {
     private final int cumulativeExp;
     private final int recyclingContributionExp;
     private final int itemContributionExp;
+    private final String modelUri;
     private final NextLevelConditionDto nextLevel;
     private final IslandEffectDto effects;
 
-    public static MemberIslandDto from(MemberIsland island, NextLevelConditionDto nextLevel) {
+    public static MemberIslandDto from(MemberIsland island, String modelUri, NextLevelConditionDto nextLevel) {
         return new MemberIslandDto(
                 island.getNickname(),
                 island.getRegion(),
@@ -26,6 +27,7 @@ public class MemberIslandDto {
                 island.getCumulativeExp(),
                 island.getRecyclingContributionExp(),
                 island.getItemContributionExp(),
+                modelUri,
                 nextLevel,
                 IslandEffectDto.empty()
         );
@@ -33,6 +35,7 @@ public class MemberIslandDto {
 
     public static MemberIslandDto from(
             MemberIsland island,
+            String modelUri,
             NextLevelConditionDto nextLevel,
             IslandEffectDto effects
     ) {
@@ -43,6 +46,7 @@ public class MemberIslandDto {
                 island.getCumulativeExp(),
                 island.getRecyclingContributionExp(),
                 island.getItemContributionExp(),
+                modelUri,
                 nextLevel,
                 effects
         );

--- a/src/main/java/store/sonyk9919/api/domain/island/entity/Item.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/Item.java
@@ -21,6 +21,9 @@ public class Item {
     @Column(name = "item_id")
     private Long id;
 
+    @Column(nullable = false, unique = true)
+    private String code;
+
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -26,6 +26,7 @@ public class IslandLevelService {
     private final ItemCache itemCache;
     private final BuildingMetadataCache buildingMetadataCache;
     private final MemberIslandRepository memberIslandRepository;
+    private final IslandModelUriResolver islandModelUriResolver;
 
     @DistributedLock(key = "'island:' + #memberAccountId + ':exp'")
     @Transactional
@@ -47,10 +48,10 @@ public class IslandLevelService {
     }
 
     private LevelUpResult checkAndProcessLevelUp(MemberIsland island) {
-        if (island.isMaxLevel()) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, null));
+        if (island.isMaxLevel()) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, islandModelUriResolver.resolve(island), null));
 
         LevelSpec currentSpec = getLevelSpec(island.getLevel());
-        if (!island.canLevelUp(currentSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, buildNextLevelCondition(island)));
+        if (!island.canLevelUp(currentSpec)) return LevelUpResult.noLevelUp(MemberIslandDto.from(island, islandModelUriResolver.resolve(island), buildNextLevelCondition(island)));
 
         island.levelUp();
         return buildLevelUpResult(island);
@@ -62,12 +63,12 @@ public class IslandLevelService {
         LevelSpec newLevelSpec = getLevelSpec(newLevel);
         if (reachedMaxLevel) {
             return LevelUpResult.of(
-                    MemberIslandDto.from(island, null),
+                    MemberIslandDto.from(island, islandModelUriResolver.resolve(island), null),
                     LevelUpResult.UnlockNotice.of(true, newLevelSpec.getMaxSlotCount(), List.of(), List.of())
             );
         }
         return LevelUpResult.of(
-                MemberIslandDto.from(island, buildNextLevelCondition(island)),
+                MemberIslandDto.from(island, islandModelUriResolver.resolve(island), buildNextLevelCondition(island)),
                 LevelUpResult.UnlockNotice.of(false, newLevelSpec.getMaxSlotCount(), getUnlockedItems(newLevel), getUnlockedBuildings(newLevel))
         );
     }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
@@ -1,0 +1,35 @@
+package store.sonyk9919.api.domain.island.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+
+@Component
+@RequiredArgsConstructor
+public class IslandModelUriResolver {
+
+    private static final String SOIL_PURIFICATION_ITEM_NAME = "토양 정화";
+
+    private final IslandItemUsageRepository islandItemUsageRepository;
+    private final ItemCache itemCache;
+
+    @Value("${island.model.base-url}")
+    private String modelBaseUrl;
+
+    public String resolve(MemberIsland island) {
+        int modelIndex = Math.min(island.getLevel(), 2) + (int) getSoilPurificationCount(island);
+        return modelBaseUrl + "/island_" + modelIndex + ".glb";
+    }
+
+    private long getSoilPurificationCount(MemberIsland island) {
+        return itemCache.getAll().stream()
+                .filter(item -> SOIL_PURIFICATION_ITEM_NAME.equals(item.getName()))
+                .findFirst()
+                .flatMap(item -> islandItemUsageRepository.findByIslandAndItem(island, item))
+                .map(IslandItemUsage::getUseCount)
+                .orElse(0L);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
@@ -11,7 +11,7 @@ import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 @RequiredArgsConstructor
 public class IslandModelUriResolver {
 
-    private static final String SOIL_PURIFICATION_ITEM_NAME = "토양 정화";
+    private static final String SOIL_PURIFICATION_CODE = "SOIL_PURIFICATION";
 
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final ItemCache itemCache;
@@ -26,7 +26,7 @@ public class IslandModelUriResolver {
 
     private long getSoilPurificationCount(MemberIsland island) {
         return itemCache.getAll().stream()
-                .filter(item -> SOIL_PURIFICATION_ITEM_NAME.equals(item.getName()))
+                .filter(item -> SOIL_PURIFICATION_CODE.equals(item.getCode()))
                 .findFirst()
                 .flatMap(item -> islandItemUsageRepository.findByIslandAndItem(island, item))
                 .map(IslandItemUsage::getUseCount)

--- a/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryService.java
@@ -28,6 +28,7 @@ public class MemberIslandRegistryService {
     private final ResourceSetupService resourceSetupService;
     private final LevelSpecCache levelSpecCache;
     private final IslandBoostCache islandBoostCache;
+    private final IslandModelUriResolver islandModelUriResolver;
 
     @Transactional
     public MemberIsland create(Long memberAccountId, String nickname, Region region) {
@@ -37,7 +38,7 @@ public class MemberIslandRegistryService {
     @Transactional
     public MemberIslandDto createDto(Long memberAccountId, String nickname, Region region) {
         MemberIsland island = createEntity(memberAccountId, nickname, region);
-        return MemberIslandDto.from(island, buildNextLevelCondition(island));
+        return MemberIslandDto.from(island, islandModelUriResolver.resolve(island), buildNextLevelCondition(island));
     }
 
     private MemberIsland createEntity(Long memberAccountId, String nickname, Region region) {
@@ -57,7 +58,7 @@ public class MemberIslandRegistryService {
     public MemberIslandDto getIslandDto(Long memberAccountId) {
         MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
                 .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
-        return MemberIslandDto.from(island, buildNextLevelCondition(island), createIslandEffect(island));
+        return MemberIslandDto.from(island, islandModelUriResolver.resolve(island), buildNextLevelCondition(island), createIslandEffect(island));
     }
 
     private NextLevelConditionDto buildNextLevelCondition(MemberIsland island) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,3 +46,7 @@ rabbitmq:
   exchange: analysis.exchange
   request-routing-key: analysis.request
   result-routing-key: analysis.result
+
+island:
+  model:
+    base-url: https://image.sonyk9919.store:20024

--- a/src/main/resources/db/item.sql
+++ b/src/main/resources/db/item.sql
@@ -1,5 +1,5 @@
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (소)', 100, 2, 3, 250);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (대)', 100, 4, 3, 250);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('토양 정화', 50, 4, 3, 125);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (소)', 25, 10,2, 50);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (대)', 40, 3, 3, 70);
+insert into item (name, price, max_count, unlock_level, exp_reward) values ('토양 정화', 50, 4, 2, 125);
 insert into item (name, price, max_count, unlock_level, exp_reward) values ('수질 개선', 50, 10, 4, 125);
 insert into item (name, price, max_count, unlock_level, exp_reward) values ('나무 심기', 30, 10, 5, 75);

--- a/src/main/resources/db/item.sql
+++ b/src/main/resources/db/item.sql
@@ -1,5 +1,5 @@
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (소)', 25, 10,2, 50);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('쓰레기 제거 (대)', 40, 3, 3, 70);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('토양 정화', 50, 4, 2, 125);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('수질 개선', 50, 10, 4, 125);
-insert into item (name, price, max_count, unlock_level, exp_reward) values ('나무 심기', 30, 10, 5, 75);
+insert into item (code, name, price, max_count, unlock_level, exp_reward) values ('TRASH_REMOVAL_SMALL', '쓰레기 제거 (소)', 25, 10, 2, 50);
+insert into item (code, name, price, max_count, unlock_level, exp_reward) values ('TRASH_REMOVAL_LARGE', '쓰레기 제거 (대)', 40, 3, 3, 70);
+insert into item (code, name, price, max_count, unlock_level, exp_reward) values ('SOIL_PURIFICATION', '토양 정화', 50, 4, 2, 125);
+insert into item (code, name, price, max_count, unlock_level, exp_reward) values ('WATER_IMPROVEMENT', '수질 개선', 50, 10, 4, 125);
+insert into item (code, name, price, max_count, unlock_level, exp_reward) values ('TREE_PLANTING', '나무 심기', 30, 10, 5, 75);

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandLevelServiceTest.java
@@ -30,9 +30,11 @@ class IslandLevelServiceTest {
     @Mock private ItemCache itemCache;
     @Mock private BuildingMetadataCache buildingMetadataCache;
     @Mock private MemberIslandRepository memberIslandRepository;
+    @Mock private IslandModelUriResolver islandModelUriResolver;
     @InjectMocks private IslandLevelService islandLevelService;
 
     private static final Long MEMBER_ID = 1L;
+    private static final String MODEL_URI = "https://image.sonyk9919.store:20024/island_1.glb";
 
     private MemberIsland island;
     private LevelSpec currentSpec;
@@ -44,6 +46,7 @@ class IslandLevelServiceTest {
         currentSpec = mock(LevelSpec.class);
         nextLevelSpec = mock(LevelSpec.class);
         given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
+        given(islandModelUriResolver.resolve(island)).willReturn(MODEL_URI);
     }
 
     @Test

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
@@ -1,0 +1,114 @@
+package store.sonyk9919.api.domain.island.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
+import store.sonyk9919.api.domain.island.entity.Item;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class IslandModelUriResolverTest {
+
+    @Mock private IslandItemUsageRepository islandItemUsageRepository;
+    @Mock private ItemCache itemCache;
+    @InjectMocks private IslandModelUriResolver islandModelUriResolver;
+
+    private static final String MODEL_BASE_URL = "https://image.sonyk9919.store:20024";
+    private MemberIsland island;
+    private Item soilPurificationItem;
+
+    @BeforeEach
+    void setUp() {
+        island = mock(MemberIsland.class);
+        soilPurificationItem = mock(Item.class);
+        ReflectionTestUtils.setField(islandModelUriResolver, "modelBaseUrl", MODEL_BASE_URL);
+        given(itemCache.getAll()).willReturn(List.of(soilPurificationItem));
+        given(soilPurificationItem.getName()).willReturn("토양 정화");
+    }
+
+    @Test
+    void resolve_레벨1_토양정화_미구매_시_island_1_모델을_반환한다() {
+        // given
+        given(island.getLevel()).willReturn(1);
+        given(islandItemUsageRepository.findByIslandAndItem(island, soilPurificationItem))
+                .willReturn(Optional.empty());
+
+        // when
+        String modelUri = islandModelUriResolver.resolve(island);
+
+        // then
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_1.glb");
+    }
+
+    @Test
+    void resolve_레벨2_토양정화_미구매_시_island_2_모델을_반환한다() {
+        // given
+        given(island.getLevel()).willReturn(2);
+        given(islandItemUsageRepository.findByIslandAndItem(island, soilPurificationItem))
+                .willReturn(Optional.empty());
+
+        // when
+        String modelUri = islandModelUriResolver.resolve(island);
+
+        // then
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_2.glb");
+    }
+
+    @Test
+    void resolve_레벨3이상_토양정화_미구매_시_island_2_모델을_반환한다() {
+        // given
+        given(island.getLevel()).willReturn(3);
+        given(islandItemUsageRepository.findByIslandAndItem(island, soilPurificationItem))
+                .willReturn(Optional.empty());
+
+        // when
+        String modelUri = islandModelUriResolver.resolve(island);
+
+        // then
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_2.glb");
+    }
+
+    @Test
+    void resolve_레벨3이상_토양정화_1회_구매_시_island_3_모델을_반환한다() {
+        // given
+        IslandItemUsage usage = mock(IslandItemUsage.class);
+        given(island.getLevel()).willReturn(3);
+        given(islandItemUsageRepository.findByIslandAndItem(island, soilPurificationItem))
+                .willReturn(Optional.of(usage));
+        given(usage.getUseCount()).willReturn(1L);
+
+        // when
+        String modelUri = islandModelUriResolver.resolve(island);
+
+        // then
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_3.glb");
+    }
+
+    @Test
+    void resolve_레벨3이상_토양정화_4회_구매_시_island_6_모델을_반환한다() {
+        // given
+        IslandItemUsage usage = mock(IslandItemUsage.class);
+        given(island.getLevel()).willReturn(5);
+        given(islandItemUsageRepository.findByIslandAndItem(island, soilPurificationItem))
+                .willReturn(Optional.of(usage));
+        given(usage.getUseCount()).willReturn(4L);
+
+        // when
+        String modelUri = islandModelUriResolver.resolve(island);
+
+        // then
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_6.glb");
+    }
+}

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
@@ -35,7 +35,7 @@ class IslandModelUriResolverTest {
         soilPurificationItem = mock(Item.class);
         ReflectionTestUtils.setField(islandModelUriResolver, "modelBaseUrl", MODEL_BASE_URL);
         given(itemCache.getAll()).willReturn(List.of(soilPurificationItem));
-        given(soilPurificationItem.getName()).willReturn("토양 정화");
+        given(soilPurificationItem.getCode()).willReturn("SOIL_PURIFICATION");
     }
 
     @Test

--- a/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
@@ -36,13 +36,13 @@ class ItemUsageServiceTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        targetItem = createItem(1L, "쓰레기 제거 (소)", 100, 2, 3, 250);
+        targetItem = createItem(1L, "쓰레기 제거 (소)", 25, 10, 2, 50);
         allItems = List.of(
                 targetItem,
-                createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
-                createItem(3L, "토양 정화",       50,  8, 3, 125),
-                createItem(4L, "수질 개선",       50, 10, 3, 125),
-                createItem(5L, "나무 심기",       30, 20, 3, 75)
+                createItem(2L, "쓰레기 제거 (대)", 40,  3, 3, 70),
+                createItem(3L, "토양 정화",        50,  4, 2, 125),
+                createItem(4L, "수질 개선",        50, 10, 4, 125),
+                createItem(5L, "나무 심기",        30, 10, 5, 75)
         );
         island = mock(MemberIsland.class);
         given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
@@ -115,7 +115,7 @@ class ItemUsageServiceTest {
     @Test
     void getItemUsages_레벨_미달_시_purchasable이_false다() {
         // given
-        given(island.getLevel()).willReturn(2);
+        given(island.getLevel()).willReturn(1);
         given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
@@ -129,7 +129,7 @@ class ItemUsageServiceTest {
     @Test
     void getItemUsages_레벨_충족_시_purchasable이_true다() {
         // given
-        given(island.getLevel()).willReturn(3);
+        given(island.getLevel()).willReturn(5);
         given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
@@ -146,7 +146,7 @@ class ItemUsageServiceTest {
         given(island.getLevel()).willReturn(3);
         given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island))
-                .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 2L)));
+                .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 10L)));
 
         // when
         List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);

--- a/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/MemberIslandRegistryServiceTest.java
@@ -27,10 +27,12 @@ class MemberIslandRegistryServiceTest {
     @Mock private SlotSetupService slotSetupService;
     @Mock private ResourceSetupService resourceSetupService;
     @Mock private LevelSpecCache levelSpecCache;
-    @InjectMocks private MemberIslandRegistryService memberIslandRegistryService;
     @Mock private IslandBoostCache islandBoostCache;
+    @Mock private IslandModelUriResolver islandModelUriResolver;
+    @InjectMocks private MemberIslandRegistryService memberIslandRegistryService;
 
     private static final Long MEMBER_ID = 1L;
+    private static final String MODEL_URI = "https://image.sonyk9919.store:20024/island_2.glb";
     private MemberIsland island;
     private LevelSpec currentSpec;
 
@@ -39,6 +41,7 @@ class MemberIslandRegistryServiceTest {
         island = mock(MemberIsland.class);
         currentSpec = mock(LevelSpec.class);
         given(memberIslandRepository.findByMemberAccountId(MEMBER_ID)).willReturn(Optional.of(island));
+        given(islandModelUriResolver.resolve(island)).willReturn(MODEL_URI);
     }
 
     @Test
@@ -59,11 +62,26 @@ class MemberIslandRegistryServiceTest {
     void getIslandDto_최고레벨일_때_nextLevel이_null이다() {
         // given
         given(island.isMaxLevel()).willReturn(true);
+        given(island.getLevel()).willReturn(7);
 
         // when
         MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
 
         // then
         assertThat(dto.getNextLevel()).isNull();
+    }
+
+    @Test
+    void getIslandDto_modelUri가_포함된다() {
+        // given
+        given(island.isMaxLevel()).willReturn(false);
+        given(island.getLevel()).willReturn(2);
+        given(levelSpecCache.get(2)).willReturn(currentSpec);
+
+        // when
+        MemberIslandDto dto = memberIslandRegistryService.getIslandDto(MEMBER_ID);
+
+        // then
+        assertThat(dto.getModelUri()).isEqualTo(MODEL_URI);
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -55,13 +55,13 @@ class ShopServiceTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        targetItem = createItem(ITEM_ID, "쓰레기 제거 (소)", 100, 2, 3, 250);
+        targetItem = createItem(ITEM_ID, "쓰레기 제거 (소)", 25, 10, 2, 50);
         allItems = List.of(
                 targetItem,
-                createItem(2L, "쓰레기 제거 (대)", 100, 4, 3, 250),
-                createItem(3L, "토양 정화",       50,  8, 3, 125),
-                createItem(4L, "수질 개선",       50, 10, 3, 125),
-                createItem(5L, "나무 심기",       30, 20, 3, 75)
+                createItem(2L, "쓰레기 제거 (대)", 40,  3, 3, 70),
+                createItem(3L, "토양 정화",        50,  4, 2, 125),
+                createItem(4L, "수질 개선",        50, 10, 4, 125),
+                createItem(5L, "나무 심기",        30, 10, 5, 75)
         );
         island = mock(MemberIsland.class);
         given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
@@ -137,7 +137,7 @@ class ShopServiceTest {
     @Test
     void getItems_레벨_조건_미달_시_purchasable이_false다() {
         // given
-        given(island.getLevel()).willReturn(2);
+        given(island.getLevel()).willReturn(1);
         given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
 
@@ -151,7 +151,7 @@ class ShopServiceTest {
     @Test
     void getItems_레벨_충족_시_purchasable이_true다() {
         // given
-        given(island.getLevel()).willReturn(3);
+        given(island.getLevel()).willReturn(5);
         given(itemCache.getAll()).willReturn(allItems);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of());
 
@@ -167,7 +167,7 @@ class ShopServiceTest {
         // given
         given(island.getLevel()).willReturn(3);
         given(itemCache.getAll()).willReturn(allItems);
-        IslandItemUsage usage = mockUsage(targetItem, 2L);
+        IslandItemUsage usage = mockUsage(targetItem, 10L);
         given(islandItemUsageRepository.findAllByIsland(island)).willReturn(List.of(usage));
 
         // when
@@ -207,9 +207,9 @@ class ShopServiceTest {
         given(usage.getUseCount()).willReturn(0L);
         given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.of(usage));
         MemberResource updatedShell = mockShell(900L);
-        given(resourceService.subtract(island, ResourceType.SHELL, 100)).willReturn(updatedShell);
+        given(resourceService.subtract(island, ResourceType.SHELL, 25)).willReturn(updatedShell);
         LevelUpResult noLevelUp = LevelUpResult.noLevelUp(mockIslandDto(3));
-        given(islandLevelService.addItemExp(MEMBER_ID, 250)).willReturn(noLevelUp);
+        given(islandLevelService.addItemExp(MEMBER_ID, 50)).willReturn(noLevelUp);
 
         // when
         ShopPurchaseResponse result = shopService.purchaseItem(MEMBER_ID, ITEM_ID);
@@ -230,12 +230,12 @@ class ShopServiceTest {
         given(usage.getUseCount()).willReturn(0L);
         given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.of(usage));
         MemberResource updatedShell = mockShell(900L);
-        given(resourceService.subtract(island, ResourceType.SHELL, 100)).willReturn(updatedShell);
+        given(resourceService.subtract(island, ResourceType.SHELL, 25)).willReturn(updatedShell);
         LevelUpResult levelUpResult = LevelUpResult.of(
                 mockIslandDto(4),
                 LevelUpResult.UnlockNotice.of(false, 4, List.of(), List.of())
         );
-        given(islandLevelService.addItemExp(MEMBER_ID, 250)).willReturn(levelUpResult);
+        given(islandLevelService.addItemExp(MEMBER_ID, 50)).willReturn(levelUpResult);
 
         // when
         ShopPurchaseResponse result = shopService.purchaseItem(MEMBER_ID, ITEM_ID);
@@ -276,7 +276,7 @@ class ShopServiceTest {
     @Test
     void purchaseItem_레벨_미달_시_예외가_발생한다() {
         // given
-        given(island.getLevel()).willReturn(2);
+        given(island.getLevel()).willReturn(1);
         given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
 
         // when & then
@@ -291,7 +291,7 @@ class ShopServiceTest {
         given(island.getLevel()).willReturn(3);
         given(itemRepository.findById(ITEM_ID)).willReturn(Optional.of(targetItem));
         IslandItemUsage usage = mock(IslandItemUsage.class);
-        given(usage.getUseCount()).willReturn(2L);
+        given(usage.getUseCount()).willReturn(10L);
         given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.of(usage));
 
         // when & then
@@ -308,7 +308,7 @@ class ShopServiceTest {
         given(islandItemUsageRepository.findByIslandAndItem(island, targetItem)).willReturn(Optional.empty());
         given(islandItemUsageRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
         MemberResource updatedShell = mockShell(900L);
-        given(resourceService.subtract(island, ResourceType.SHELL, 100)).willReturn(updatedShell);
+        given(resourceService.subtract(island, ResourceType.SHELL, 25)).willReturn(updatedShell);
         LevelUpResult noLevelUp = LevelUpResult.noLevelUp(mockIslandDto(3));
         given(islandLevelService.addItemExp(any(), anyInt())).willReturn(noLevelUp);
 

--- a/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/shop/service/ShopServiceTest.java
@@ -259,7 +259,7 @@ class ShopServiceTest {
         given(mockIsland.getCumulativeExp()).willReturn(0);
         given(mockIsland.getRecyclingContributionExp()).willReturn(0);
         given(mockIsland.getItemContributionExp()).willReturn(0);
-        return MemberIslandDto.from(mockIsland, null);
+        return MemberIslandDto.from(mockIsland, null, null);
     }
 
     @Test


### PR DESCRIPTION
## 주요 변경사항

클라이언트가 섬 조회 API 응답에서 3D 모델 URI를 직접 받아 렌더링할 수 있도록 변경합니다.

### Feature
- `IslandModelUriResolver` 컴포넌트 추가: `섬 레벨`과 `토양 정화 아이템 구매 횟수`를 기반으로 3D 모델 URI 결정
- `MemberIslandDto`에 `modelUri` 필드 추가:`GET /v1/islands` 응답에 포함

### Chore
- `item.sql` 아이템 해금 레벨 및 스탯 기획서에 맞게 수정
  - `쓰레기 제거(소)`, `토양 정화`: 해금 레벨 3 → 2 로 변경됐으니 참고 부탁드립니다 (그 외에 획득 경험치, 조개 가격 등도 수정됨)

### Test
- `IslandModelUriResolverTest` 추가
- `item.sql` 변경에 따른 테스트 Mock 데이터 동기화 (`ShopServiceTest`, `ItemUsageServiceTest`)

## 상세 설명

- 3D 모델 파일(`.glb`)은 Nginx 정적 파일 서버(`image.sonyk9919.store:20024`)에서 서빙합니다.
- 모델 URI 결정 공식: `modelIndex = min(섬 레벨, 2) + 토양 정화 구매 횟수`
  - 레벨 1 → `island_1.glb`
  - 레벨 2 → `island_2.glb`
  - 레벨 2 이상, 토양 정화 1회 구매 → `island_3.glb` … 4회 구매 → `island_6.glb`
- 모델 base URL은 `application.yml`의 `island.model.base-url`로 관리

## 체크리스트

- [x] `GET /v1/islands` 응답에 `modelUri` 필드가 포함되는지 확인

## 참고사항

- 우선 현재 모델 파일: `island_1.glb` ~ `island_6.glb` (총 6개) 이렇게 리눅스 서버에 올라가있습니다. 
- 모델링 변경이 계속 자잘자잘하게 이루어지는데 매번 드라이브에 올리기 번거롭고 관리가 잘 안 되기도 해서, Nginx 정적 파일 서버(`image.sonyk9919.store:20024`)에서 서빙하는 게 가장 최종(?)최신(?) 버전이라고 생각해주세요!!
- 이 외에 건물 에셋 최종 완성되면 추가하고, PR #93 에 보석 교환 상점 UI에 쓸 이미지도 추가하겠습니다! 