### PR TITLE
fix: 나무, 쓰레기, 건물 glb 모델 URI 추가

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/dto/BuildingInfoDto.java
@@ -14,7 +14,7 @@ public class BuildingInfoDto {
     private Long buildingId;
     private String name;
     private String category;
-    private String model;
+    private String modelUri;
 
     private int currentLevel;
     private LocalDateTime fuelExpiredAt;
@@ -41,6 +41,32 @@ public class BuildingInfoDto {
                 metadata.getName(),
                 metadata.getCategory().name(),
                 metadata.getModel(),
+                building.getCurrentLevel(),
+                building.getFuelExpiredAt(),
+                building.getLastCollectedAt(),
+                productionInfo
+        );
+    }
+
+    public static BuildingInfoDto of(Building building, BuildingMetadata metadata, String modelUri) {
+        return new BuildingInfoDto(
+                building.getId(),
+                metadata.getName(),
+                metadata.getCategory().name(),
+                modelUri,
+                building.getCurrentLevel(),
+                building.getFuelExpiredAt(),
+                building.getLastCollectedAt(),
+                null
+        );
+    }
+
+    public static BuildingInfoDto of(Building building, BuildingMetadata metadata, ProductionInfoDto productionInfo, String modelUri) {
+        return new BuildingInfoDto(
+                building.getId(),
+                metadata.getName(),
+                metadata.getCategory().name(),
+                modelUri,
                 building.getCurrentLevel(),
                 building.getFuelExpiredAt(),
                 building.getLastCollectedAt(),

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingHarvestService.java
@@ -31,6 +31,7 @@ public class BuildingHarvestService {
     private final MemberIslandRegistryService memberIslandService;
     private final ResourceService resourceService;
     private final IslandBoostCache islandBoostCache;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     @DistributedLock(key = "'island:' + #memberId + ':harvest'")
     @Transactional
@@ -48,7 +49,7 @@ public class BuildingHarvestService {
 
         MemberResource islandGem = applyHarvest(building, island, gems, calculator);
         int remainingGem = HarvestCalculator.from(building).calculate(boostPercent);
-        SlotResponseDto slotDto = SlotResponseDto.of(slot, BuildingInfoDto.of(building, building.getBuildingMetadata()));
+        SlotResponseDto slotDto = SlotResponseDto.of(slot, BuildingInfoDto.of(building, building.getBuildingMetadata(), buildingModelUriResolver.resolve(building.getBuildingMetadata())));
         return HarvestResponseDto.from(remainingGem, islandGem, slotDto);
     }
 
@@ -70,7 +71,7 @@ public class BuildingHarvestService {
 
         MemberResource gem = resourceService.add(island, ResourceType.GEM, totalGems);
         List<SlotResponseDto> slotDtos = harvestableSlots.stream()
-                .map(slot -> SlotResponseDto.of(slot, BuildingInfoDto.of(slot.getBuilding(), slot.getBuilding().getBuildingMetadata())))
+                .map(slot -> SlotResponseDto.of(slot, BuildingInfoDto.of(slot.getBuilding(), slot.getBuilding().getBuildingMetadata(), buildingModelUriResolver.resolve(slot.getBuilding().getBuildingMetadata()))))
                 .collect(Collectors.toList());
         return HarvestResponseDto.from(gem, slotDtos);
     }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingLayoutService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingLayoutService.java
@@ -32,6 +32,7 @@ public class BuildingLayoutService {
     private final ResourceService resourceService;
     private final SlotQueryHelper slotQueryHelper;
     private final ApplicationEventPublisher eventPublisher;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     @DistributedLock(key = "'slot:' + #memberId + ':' + #slotNumber")
     @Transactional
@@ -67,7 +68,7 @@ public class BuildingLayoutService {
 
     private BuildingResponseDto createResponse(Long memberId, Slot slot, Building building) {
         BuildingInfoDto buildingInfo = building != null ?
-                BuildingInfoDto.of(building, building.getBuildingMetadata()) : null;
+                BuildingInfoDto.of(building, building.getBuildingMetadata(), buildingModelUriResolver.resolve(building.getBuildingMetadata())) : null;
 
         return BuildingResponseDto.of(
                 SlotResponseDto.of(slot, buildingInfo),

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingModelUriResolver.java
@@ -1,16 +1,17 @@
 package store.sonyk9919.api.domain.building.service;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
+import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
+@RequiredArgsConstructor
 public class BuildingModelUriResolver {
 
-    @Value("${image.base-url}")
-    private String imageBaseUrl;
+    private final UriUtils uriUtils;
 
     public String resolve(BuildingMetadata metadata) {
-        return String.format("%s/models/%s.glb", imageBaseUrl, metadata.getModel());
+        return uriUtils.glbUri(metadata.getModel());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingModelUriResolver.java
@@ -1,0 +1,16 @@
+package store.sonyk9919.api.domain.building.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
+
+@Component
+public class BuildingModelUriResolver {
+
+    @Value("${image.base-url}")
+    private String imageBaseUrl;
+
+    public String resolve(BuildingMetadata metadata) {
+        return String.format("%s/models/%s.glb", imageBaseUrl, metadata.getModel());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingMoveService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingMoveService.java
@@ -21,6 +21,7 @@ public class BuildingMoveService {
 
     private final SlotQueryHelper slotQueryHelper;
     private final SlotRepository slotRepository;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     @DistributedLock(keys = {
             "'slot:' + #memberId + ':' + #slotMoveRequestDto.fromSlotNumber",
@@ -53,7 +54,8 @@ public class BuildingMoveService {
 
         BuildingInfoDto buildingInfo = BuildingInfoDto.of(
                 slot.getBuilding(),
-                slot.getBuilding().getBuildingMetadata()
+                slot.getBuilding().getBuildingMetadata(),
+                buildingModelUriResolver.resolve(slot.getBuilding().getBuildingMetadata())
         );
         return SlotResponseDto.of(slot, buildingInfo);
     }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingOperateService.java
@@ -24,6 +24,7 @@ public class BuildingOperateService {
 
     private final ResourceService resourceService;
     private final SlotQueryHelper slotQueryHelper;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     @DistributedLock(key = "'slot:' + #memberId + ':' + #slotNumber")
     @Transactional
@@ -38,7 +39,7 @@ public class BuildingOperateService {
         building.operate(yield.getDurationSecond());
         resourceService.subtract(slot.getIsland(), ResourceType.FUEL, yield.getRequiredFuel());
         return BuildingResponseDto.of(
-                SlotResponseDto.of(slot, BuildingInfoDto.of(building, buildingMetadata)),
+                SlotResponseDto.of(slot, BuildingInfoDto.of(building, buildingMetadata, buildingModelUriResolver.resolve(buildingMetadata))),
                 resourceService.getBalance(memberId)
         );
     }

--- a/src/main/java/store/sonyk9919/api/domain/building/service/BuildingUpgradeService.java
+++ b/src/main/java/store/sonyk9919/api/domain/building/service/BuildingUpgradeService.java
@@ -27,6 +27,7 @@ public class BuildingUpgradeService {
     private final ResourceService resourceService;
     private final SlotQueryHelper slotQueryHelper;
     private final ApplicationEventPublisher eventPublisher;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     @DistributedLock(key = "'slot:' + #memberId + ':' + #slotNumber")
     @Transactional
@@ -65,6 +66,6 @@ public class BuildingUpgradeService {
     private BuildingInfoDto mapToBuildingInfo(Building building){
         if (building == null) return null;
 
-        return BuildingInfoDto.of(building, building.getBuildingMetadata());
+        return BuildingInfoDto.of(building, building.getBuildingMetadata(), buildingModelUriResolver.resolve(building.getBuildingMetadata()));
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/controller/MemberIslandController.java
@@ -10,7 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
 import store.sonyk9919.api.domain.auth.entity.AuthMember;
-import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
+import store.sonyk9919.api.domain.island.dto.ItemUsageDto;
 import store.sonyk9919.api.domain.island.dto.MemberIslandCreateRequestDto;
 import store.sonyk9919.api.domain.island.dto.MemberIslandDto;
 import store.sonyk9919.api.domain.island.service.ItemUsageService;
@@ -63,7 +63,7 @@ public class MemberIslandController {
     })
     @GetMapping("/items/usages")
     @ResponseStatus(HttpStatus.OK)
-    public List<ItemCatalogDto> getItemUsages(
+    public List<ItemUsageDto> getItemUsages(
             @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
     ) {
         return itemUsageService.getItemUsages(authMember.getId());

--- a/src/main/java/store/sonyk9919/api/domain/island/dto/ItemCatalogDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/ItemCatalogDto.java
@@ -17,9 +17,8 @@ public class ItemCatalogDto {
     private final int unlockLevel;
     private final int expReward;
     private final boolean purchasable;
-    private final String iconUri;
 
-    public static ItemCatalogDto from(ShopItem item, long currentCount, boolean purchasable, String iconUri) {
+    public static ItemCatalogDto from(ShopItem item, long currentCount, boolean purchasable) {
         return new ItemCatalogDto(
                 item.getId(),
                 item.getName(),
@@ -28,8 +27,7 @@ public class ItemCatalogDto {
                 currentCount,
                 item.getUnlockLevel(),
                 item.getExpReward(),
-                purchasable,
-                iconUri
+                purchasable
         );
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/dto/ItemUsageDto.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/dto/ItemUsageDto.java
@@ -1,0 +1,38 @@
+package store.sonyk9919.api.domain.island.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import store.sonyk9919.api.domain.shop.entity.ShopItem;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ItemUsageDto {
+
+    private final Long itemId;
+    private final String name;
+    private final int price;
+    private final int maxCount;
+    private final long currentCount;
+    private final int unlockLevel;
+    private final int expReward;
+    private final boolean purchasable;
+    private final List<String> modelUri;
+
+    public static ItemUsageDto from(
+            ShopItem item, long currentCount, boolean purchasable, List<String> modelUri
+    ) {
+        return new ItemUsageDto(
+                item.getId(),
+                item.getName(),
+                item.getPrice(),
+                item.getMaxCount(),
+                currentCount,
+                item.getUnlockLevel(),
+                item.getExpReward(),
+                purchasable,
+                modelUri
+        );
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandLevelService.java
@@ -14,7 +14,6 @@ import store.sonyk9919.api.domain.island.entity.LevelSpec;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
-import store.sonyk9919.api.domain.shop.service.IconUriResolver;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
 import store.sonyk9919.api.global.common.exception.CustomException;
 import store.sonyk9919.api.global.common.lock.DistributedLock;
@@ -26,7 +25,6 @@ public class IslandLevelService {
 
     private final LevelSpecCache levelSpecCache;
     private final ShopItemCache shopItemCache;
-    private final IconUriResolver iconUriResolver;
     private final BuildingMetadataCache buildingMetadataCache;
     private final MemberIslandRepository memberIslandRepository;
     private final IslandModelUriResolver islandModelUriResolver;
@@ -85,7 +83,7 @@ public class IslandLevelService {
     private List<ItemCatalogDto> getUnlockedItems(int newLevel) {
         return shopItemCache.getAll().stream()
                 .filter(i -> i.getUnlockLevel() == newLevel)
-                .map(i -> ItemCatalogDto.from(i, 0L, true, iconUriResolver.resolve(i)))
+                .map(i -> ItemCatalogDto.from(i, 0L, true))
                 .toList();
     }
 

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
@@ -5,14 +5,13 @@ import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
+import store.sonyk9919.api.domain.shop.entity.ShopItemCode;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
 import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
 @RequiredArgsConstructor
 public class IslandModelUriResolver {
-
-    private static final String SOIL_PURIFICATION_CODE = "SOIL_PURIFICATION";
 
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final ShopItemCache shopItemCache;
@@ -25,7 +24,7 @@ public class IslandModelUriResolver {
 
     private long getSoilPurificationCount(MemberIsland island) {
         return shopItemCache.getAll().stream()
-                .filter(item -> SOIL_PURIFICATION_CODE.equals(item.getCode()))
+                .filter(item -> item.getCode() == ShopItemCode.SOIL_PURIFICATION)
                 .findFirst()
                 .flatMap(item -> islandItemUsageRepository.findByIslandAndItem(island, item))
                 .map(IslandItemUsage::getUseCount)

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
@@ -22,7 +22,7 @@ public class IslandModelUriResolver {
 
     public String resolve(MemberIsland island) {
         int modelIndex = Math.min(island.getLevel(), 2) + (int) getSoilPurificationCount(island);
-        return String.format("%s/island_%d.glb", imageBaseUrl, modelIndex);
+        return String.format("%s/models/island_%d.glb", imageBaseUrl, modelIndex);
     }
 
     private long getSoilPurificationCount(MemberIsland island) {

--- a/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolver.java
@@ -1,12 +1,12 @@
 package store.sonyk9919.api.domain.island.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
+import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -16,13 +16,11 @@ public class IslandModelUriResolver {
 
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final ShopItemCache shopItemCache;
-
-    @Value("${image.base-url}")
-    private String imageBaseUrl;
+    private final UriUtils uriUtils;
 
     public String resolve(MemberIsland island) {
         int modelIndex = Math.min(island.getLevel(), 2) + (int) getSoilPurificationCount(island);
-        return String.format("%s/models/island_%d.glb", imageBaseUrl, modelIndex);
+        return uriUtils.glbUri("island_" + modelIndex);
     }
 
     private long getSoilPurificationCount(MemberIsland island) {

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
@@ -6,25 +6,22 @@ import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
+import store.sonyk9919.api.domain.shop.entity.ShopItemCode;
 import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
 @RequiredArgsConstructor
 public class ItemModelUriResolver {
 
-    private static final String TREE_PLANTING_CODE = "TREE_PLANTING";
-    private static final String TRASH_SMALL_CODE   = "TRASH_REMOVAL_SMALL";
-    private static final String TRASH_LARGE_CODE   = "TRASH_REMOVAL_LARGE";
-
     private final UriUtils uriUtils;
 
     public List<String> resolve(ShopItem item) {
         return switch (item.getCode()) {
-            case TREE_PLANTING_CODE -> List.of(uriUtils.glbUri("tree_1"), uriUtils.glbUri("tree_2"));
-            case TRASH_SMALL_CODE -> IntStream.rangeClosed(1, 10)
+            case TREE_PLANTING -> List.of(uriUtils.glbUri("tree_1"), uriUtils.glbUri("tree_2"));
+            case TRASH_REMOVAL_SMALL -> IntStream.rangeClosed(1, 10)
                     .mapToObj(i -> uriUtils.glbUri("trash_small_" + i))
                     .collect(Collectors.toList());
-            case TRASH_LARGE_CODE -> List.of(
+            case TRASH_REMOVAL_LARGE -> List.of(
                     uriUtils.glbUri("trash_large_1"), uriUtils.glbUri("trash_large_2"), uriUtils.glbUri("trash_large_3"));
             default -> List.of();
         };

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
@@ -3,33 +3,30 @@ package store.sonyk9919.api.domain.island.service;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
+import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
+@RequiredArgsConstructor
 public class ItemModelUriResolver {
 
     private static final String TREE_PLANTING_CODE = "TREE_PLANTING";
     private static final String TRASH_SMALL_CODE   = "TRASH_REMOVAL_SMALL";
     private static final String TRASH_LARGE_CODE   = "TRASH_REMOVAL_LARGE";
 
-    @Value("${image.base-url}")
-    private String imageBaseUrl;
+    private final UriUtils uriUtils;
 
     public List<String> resolve(ShopItem item) {
         return switch (item.getCode()) {
-            case TREE_PLANTING_CODE -> List.of(modelUri("tree_1"), modelUri("tree_2"));
+            case TREE_PLANTING_CODE -> List.of(uriUtils.glbUri("tree_1"), uriUtils.glbUri("tree_2"));
             case TRASH_SMALL_CODE -> IntStream.rangeClosed(1, 10)
-                    .mapToObj(i -> modelUri("trash_small_" + i))
+                    .mapToObj(i -> uriUtils.glbUri("trash_small_" + i))
                     .collect(Collectors.toList());
             case TRASH_LARGE_CODE -> List.of(
-                    modelUri("trash_large_1"), modelUri("trash_large_2"), modelUri("trash_large_3"));
+                    uriUtils.glbUri("trash_large_1"), uriUtils.glbUri("trash_large_2"), uriUtils.glbUri("trash_large_3"));
             default -> List.of();
         };
-    }
-
-    private String modelUri(String baseFilename) {
-        return String.format("%s/models/%s.glb", imageBaseUrl, baseFilename);
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemModelUriResolver.java
@@ -1,0 +1,35 @@
+package store.sonyk9919.api.domain.island.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import store.sonyk9919.api.domain.shop.entity.ShopItem;
+
+@Component
+public class ItemModelUriResolver {
+
+    private static final String TREE_PLANTING_CODE = "TREE_PLANTING";
+    private static final String TRASH_SMALL_CODE   = "TRASH_REMOVAL_SMALL";
+    private static final String TRASH_LARGE_CODE   = "TRASH_REMOVAL_LARGE";
+
+    @Value("${image.base-url}")
+    private String imageBaseUrl;
+
+    public List<String> resolve(ShopItem item) {
+        return switch (item.getCode()) {
+            case TREE_PLANTING_CODE -> List.of(modelUri("tree_1"), modelUri("tree_2"));
+            case TRASH_SMALL_CODE -> IntStream.rangeClosed(1, 10)
+                    .mapToObj(i -> modelUri("trash_small_" + i))
+                    .collect(Collectors.toList());
+            case TRASH_LARGE_CODE -> List.of(
+                    modelUri("trash_large_1"), modelUri("trash_large_2"), modelUri("trash_large_3"));
+            default -> List.of();
+        };
+    }
+
+    private String modelUri(String baseFilename) {
+        return String.format("%s/models/%s.glb", imageBaseUrl, baseFilename);
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/ItemUsageService.java
@@ -6,11 +6,10 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
+import store.sonyk9919.api.domain.island.dto.ItemUsageDto;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
-import store.sonyk9919.api.domain.shop.service.IconUriResolver;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
 
 @Service
@@ -21,14 +20,14 @@ public class ItemUsageService {
     private final MemberIslandRegistryService memberIslandRegistryService;
     private final IslandItemUsageRepository islandItemUsageRepository;
     private final ShopItemCache shopItemCache;
-    private final IconUriResolver iconUriResolver;
+    private final ItemModelUriResolver itemModelUriResolver;
 
-    public List<ItemCatalogDto> getItemUsages(Long memberAccountId) {
+    public List<ItemUsageDto> getItemUsages(Long memberAccountId) {
         MemberIsland island = memberIslandRegistryService.getIsland(memberAccountId);
         List<ShopItem> items = shopItemCache.getAll();
         Map<Long, Long> usageByItemId = buildUsageMap(island);
         return items.stream()
-                .map(item -> toItemCatalogDto(item, usageByItemId, island))
+                .map(item -> toItemUsageDto(item, usageByItemId, island))
                 .collect(Collectors.toList());
     }
 
@@ -40,10 +39,10 @@ public class ItemUsageService {
                 ));
     }
 
-    private ItemCatalogDto toItemCatalogDto(ShopItem item, Map<Long, Long> usageByItemId, MemberIsland island) {
+    private ItemUsageDto toItemUsageDto(ShopItem item, Map<Long, Long> usageByItemId, MemberIsland island) {
         long currentCount = usageByItemId.getOrDefault(item.getId(), 0L);
         boolean purchasable = island.getLevel() >= item.getUnlockLevel()
                 && currentCount < item.getMaxCount();
-        return ItemCatalogDto.from(item, currentCount, purchasable, iconUriResolver.resolve(item));
+        return ItemUsageDto.from(item, currentCount, purchasable, itemModelUriResolver.resolve(item));
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/shop/entity/ShopItem.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/entity/ShopItem.java
@@ -2,6 +2,8 @@ package store.sonyk9919.api.domain.shop.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,8 +23,9 @@ public class ShopItem {
     @Column(name = "item_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, unique = true)
-    private String code;
+    private ShopItemCode code;
 
     @Column(nullable = false)
     private String name;
@@ -40,6 +43,6 @@ public class ShopItem {
     private int expReward;
 
     public String toFilename() {
-        return code.toLowerCase().replace('_', '-');
+        return code.name().toLowerCase().replace('_', '-');
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/shop/entity/ShopItemCode.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/entity/ShopItemCode.java
@@ -1,0 +1,9 @@
+package store.sonyk9919.api.domain.shop.entity;
+
+public enum ShopItemCode {
+    TRASH_REMOVAL_SMALL,
+    TRASH_REMOVAL_LARGE,
+    SOIL_PURIFICATION,
+    WATER_IMPROVEMENT,
+    TREE_PLANTING
+}

--- a/src/main/java/store/sonyk9919/api/domain/shop/service/IconUriResolver.java
+++ b/src/main/java/store/sonyk9919/api/domain/shop/service/IconUriResolver.java
@@ -1,21 +1,22 @@
 package store.sonyk9919.api.domain.shop.service;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import store.sonyk9919.api.domain.shop.entity.GemItem;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
+import store.sonyk9919.api.global.common.UriUtils;
 
 @Component
+@RequiredArgsConstructor
 public class IconUriResolver {
 
-    @Value("${image.base-url}")
-    private String imageBaseUrl;
+    private final UriUtils uriUtils;
 
     public String resolve(ShopItem item) {
-        return String.format("%s/shop-icons/%s.png", imageBaseUrl, item.toFilename());
+        return uriUtils.shopIconUri(item.toFilename());
     }
 
     public String resolve(GemItem item) {
-        return String.format("%s/gem-icons/%s.png", imageBaseUrl, item.toFilename());
+        return uriUtils.gemIconUri(item.toFilename());
     }
 }

--- a/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
+++ b/src/main/java/store/sonyk9919/api/domain/slot/service/SlotQueryService.java
@@ -10,6 +10,7 @@ import store.sonyk9919.api.domain.building.dto.BuildingInfoDto;
 import store.sonyk9919.api.domain.building.dto.ProductionInfoDto;
 import store.sonyk9919.api.domain.building.entity.Building;
 import store.sonyk9919.api.domain.building.entity.BuildingMetadata;
+import store.sonyk9919.api.domain.building.service.BuildingModelUriResolver;
 import store.sonyk9919.api.domain.building.service.HarvestCalculator;
 import store.sonyk9919.api.domain.building.service.IslandBoostCache;
 import store.sonyk9919.api.domain.island.entity.LevelSpec;
@@ -35,6 +36,7 @@ public class SlotQueryService {
     private final MemberIslandRegistryService memberIslandService;
     private final IslandBoostCache islandBoostCache;
     private final LevelSpecCache levelSpecCache;
+    private final BuildingModelUriResolver buildingModelUriResolver;
 
     public SlotListResponseDto getAllSlot(Long memberId) {
         MemberIsland island = memberIslandService.getIsland(memberId);
@@ -56,7 +58,7 @@ public class SlotQueryService {
     private BuildingInfoDto mapToBuildingInfo(Building building){
         if (building == null) return null;
 
-        return BuildingInfoDto.of(building, building.getBuildingMetadata());
+        return BuildingInfoDto.of(building, building.getBuildingMetadata(), buildingModelUriResolver.resolve(building.getBuildingMetadata()));
     }
 
     public SlotResponseDto getSlotDetail(Long memberId, Integer slotNumber) {
@@ -74,7 +76,9 @@ public class SlotQueryService {
         BuildingMetadata metadata = building.getBuildingMetadata();
         return BuildingInfoDto.of(
                 building, metadata,
-                createInfo(island, building, metadata));
+                createInfo(island, building, metadata),
+                buildingModelUriResolver.resolve(metadata));
+
     }
 
     private ProductionInfoDto createInfo(MemberIsland island, Building building, BuildingMetadata metadata) {

--- a/src/main/java/store/sonyk9919/api/global/common/UriUtils.java
+++ b/src/main/java/store/sonyk9919/api/global/common/UriUtils.java
@@ -1,0 +1,23 @@
+package store.sonyk9919.api.global.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UriUtils {
+
+    @Value("${image.base-url}")
+    private String imageBaseUrl;
+
+    public String glbUri(String baseFilename) {
+        return String.format("%s/models/%s.glb", imageBaseUrl, baseFilename);
+    }
+
+    public String shopIconUri(String filename) {
+        return String.format("%s/shop-icons/%s.png", imageBaseUrl, filename);
+    }
+
+    public String gemIconUri(String filename) {
+        return String.format("%s/gem-icons/%s.png", imageBaseUrl, filename);
+    }
+}

--- a/src/main/resources/db/building_metadata.sql
+++ b/src/main/resources/db/building_metadata.sql
@@ -1,8 +1,8 @@
 INSERT INTO building_metadata (category, name, model) VALUES
-('PRODUCTION', '풍력 발전소', 'model_wind_01'),
-('PRODUCTION', '폐기물 분류기', 'model_waste_01'),
-('PRODUCTION', '옷 재활용 공장', 'model_clothes_01'),
-('PRODUCTION', '플라스틱 재활용 공장', 'model_plastic_01'),
+('PRODUCTION', '풍력 발전소', 'production_wind_generator'),
+('PRODUCTION', '폐기물 분류기', 'production_waste_classifier'),
+('PRODUCTION', '옷 재활용 공장', 'production_clothes_recycling'),
+('PRODUCTION', '플라스틱 재활용 공장', 'production_plastic_recycling'),
 
-('PURIFICATION', '재활용 분류기', 'model_recycle_01'),
-('PURIFICATION', '대기 정화 타워', 'model_purity_01');
+('PURIFICATION', '재활용 분류기', 'purification_recycling_classifier'),
+('PURIFICATION', '대기 정화 타워', 'purification_air_purifier');

--- a/src/test/java/store/sonyk9919/api/domain/building/service/BuildingLayoutServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/building/service/BuildingLayoutServiceTest.java
@@ -32,6 +32,7 @@ import store.sonyk9919.api.domain.slot.dto.SlotMoveRequestDto;
 import store.sonyk9919.api.domain.slot.entity.Slot;
 import store.sonyk9919.api.domain.slot.repository.SlotRepository;
 import store.sonyk9919.api.domain.slot.service.SlotQueryHelper;
+import store.sonyk9919.api.domain.building.service.BuildingModelUriResolver;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -46,6 +47,7 @@ class BuildingLayoutServiceTest {
     @Mock private SlotRepository slotRepository;
     @Mock private SlotQueryHelper slotQueryHelper;
     @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private BuildingModelUriResolver buildingModelUriResolver;
 
     private MemberIsland island;
     private Slot slot;

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
@@ -12,18 +12,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
+import store.sonyk9919.api.global.common.UriUtils;
 
 @ExtendWith(MockitoExtension.class)
 class IslandModelUriResolverTest {
 
     @Mock private IslandItemUsageRepository islandItemUsageRepository;
     @Mock private ShopItemCache shopItemCache;
+    @Mock private UriUtils uriUtils;
     @InjectMocks private IslandModelUriResolver islandModelUriResolver;
 
     private static final String MODEL_BASE_URL = "https://image.sonyk9919.store:20024";
@@ -34,7 +35,8 @@ class IslandModelUriResolverTest {
     void setUp() {
         island = mock(MemberIsland.class);
         soilPurificationItem = mock(ShopItem.class);
-        ReflectionTestUtils.setField(islandModelUriResolver, "imageBaseUrl", MODEL_BASE_URL);
+        given(uriUtils.glbUri(org.mockito.ArgumentMatchers.anyString()))
+                .willAnswer(inv -> MODEL_BASE_URL + "/models/" + inv.getArgument(0) + ".glb");
         given(shopItemCache.getAll()).willReturn(List.of(soilPurificationItem));
         given(soilPurificationItem.getCode()).willReturn("SOIL_PURIFICATION");
     }

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
@@ -50,7 +50,7 @@ class IslandModelUriResolverTest {
         String modelUri = islandModelUriResolver.resolve(island);
 
         // then
-        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_1.glb");
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/models/island_1.glb");
     }
 
     @Test
@@ -64,7 +64,7 @@ class IslandModelUriResolverTest {
         String modelUri = islandModelUriResolver.resolve(island);
 
         // then
-        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_2.glb");
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/models/island_2.glb");
     }
 
     @Test
@@ -78,7 +78,7 @@ class IslandModelUriResolverTest {
         String modelUri = islandModelUriResolver.resolve(island);
 
         // then
-        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_2.glb");
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/models/island_2.glb");
     }
 
     @Test
@@ -94,7 +94,7 @@ class IslandModelUriResolverTest {
         String modelUri = islandModelUriResolver.resolve(island);
 
         // then
-        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_3.glb");
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/models/island_3.glb");
     }
 
     @Test
@@ -110,6 +110,6 @@ class IslandModelUriResolverTest {
         String modelUri = islandModelUriResolver.resolve(island);
 
         // then
-        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/island_6.glb");
+        assertThat(modelUri).isEqualTo(MODEL_BASE_URL + "/models/island_6.glb");
     }
 }

--- a/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/IslandModelUriResolverTest.java
@@ -16,6 +16,7 @@ import store.sonyk9919.api.domain.island.entity.IslandItemUsage;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
+import store.sonyk9919.api.domain.shop.entity.ShopItemCode;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
 import store.sonyk9919.api.global.common.UriUtils;
 
@@ -38,7 +39,7 @@ class IslandModelUriResolverTest {
         given(uriUtils.glbUri(org.mockito.ArgumentMatchers.anyString()))
                 .willAnswer(inv -> MODEL_BASE_URL + "/models/" + inv.getArgument(0) + ".glb");
         given(shopItemCache.getAll()).willReturn(List.of(soilPurificationItem));
-        given(soilPurificationItem.getCode()).willReturn("SOIL_PURIFICATION");
+        given(soilPurificationItem.getCode()).willReturn(ShopItemCode.SOIL_PURIFICATION);
     }
 
     @Test

--- a/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
+++ b/src/test/java/store/sonyk9919/api/domain/island/service/ItemUsageServiceTest.java
@@ -14,12 +14,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import store.sonyk9919.api.domain.island.dto.ItemCatalogDto;
+import store.sonyk9919.api.domain.island.dto.ItemUsageDto;
 import store.sonyk9919.api.domain.island.entity.MemberIsland;
 import store.sonyk9919.api.domain.island.exception.IslandStatus;
 import store.sonyk9919.api.domain.island.repository.IslandItemUsageRepository;
 import store.sonyk9919.api.domain.shop.entity.ShopItem;
-import store.sonyk9919.api.domain.shop.service.IconUriResolver;
 import store.sonyk9919.api.domain.shop.service.ShopItemCache;
 import store.sonyk9919.api.global.common.exception.CustomException;
 
@@ -29,7 +28,7 @@ class ItemUsageServiceTest {
     @Mock private MemberIslandRegistryService memberIslandRegistryService;
     @Mock private IslandItemUsageRepository islandItemUsageRepository;
     @Mock private ShopItemCache shopItemCache;
-    @Mock private IconUriResolver iconUriResolver;
+    @Mock private ItemModelUriResolver itemModelUriResolver;
     @InjectMocks private ItemUsageService itemUsageService;
 
     private static final Long MEMBER_ID = 1L;
@@ -49,8 +48,8 @@ class ItemUsageServiceTest {
         );
         island = mock(MemberIsland.class);
         given(memberIslandRegistryService.getIsland(MEMBER_ID)).willReturn(island);
-        org.mockito.Mockito.lenient().when(iconUriResolver.resolve(org.mockito.ArgumentMatchers.any(ShopItem.class)))
-                .thenReturn("https://image.sonyk9919.store:20024/shop-icons/test.png");
+        org.mockito.Mockito.lenient().when(itemModelUriResolver.resolve(org.mockito.ArgumentMatchers.any(ShopItem.class)))
+                .thenReturn(List.of());
     }
 
     private ShopItem createItem(Long id, String name, int price, int maxCount, int unlockLevel, int expReward)
@@ -75,7 +74,7 @@ class ItemUsageServiceTest {
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
         assertThat(result).hasSize(5);
@@ -89,7 +88,7 @@ class ItemUsageServiceTest {
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
         assertThat(result).allMatch(r -> r.getCurrentCount() == 0);
@@ -104,10 +103,10 @@ class ItemUsageServiceTest {
                 .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 1L)));
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
-        ItemCatalogDto response = result.stream()
+        ItemUsageDto response = result.stream()
                 .filter(r -> r.getItemId().equals(targetItem.getId()))
                 .findFirst().orElseThrow();
         assertThat(response.getCurrentCount()).isEqualTo(1L);
@@ -125,7 +124,7 @@ class ItemUsageServiceTest {
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
         assertThat(result).allMatch(r -> !r.isPurchasable());
@@ -139,10 +138,10 @@ class ItemUsageServiceTest {
         given(islandItemUsageRepository.findItemIdAndUseCountByIsland(island)).willReturn(List.of());
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
-        assertThat(result).allMatch(ItemCatalogDto::isPurchasable);
+        assertThat(result).allMatch(ItemUsageDto::isPurchasable);
     }
 
     @Test
@@ -154,10 +153,10 @@ class ItemUsageServiceTest {
                 .willReturn(List.<Object[]>of(usageRow(targetItem.getId(), 10L)));
 
         // when
-        List<ItemCatalogDto> result = itemUsageService.getItemUsages(MEMBER_ID);
+        List<ItemUsageDto> result = itemUsageService.getItemUsages(MEMBER_ID);
 
         // then
-        ItemCatalogDto response = result.stream()
+        ItemUsageDto response = result.stream()
                 .filter(r -> r.getItemId().equals(targetItem.getId()))
                 .findFirst().orElseThrow();
         assertThat(response.isPurchasable()).isFalse();


### PR DESCRIPTION
## 주요 변경사항

3D 씬 렌더링에 필요한 **나무, 쓰레기, 건물** glb 모델 URI를 클라이언트 응답에 추가했습니다.

- `IslandModelUriResolver`의 /models/ 프리픽스 추가
- 아이템 사용량 조회 API(`GET /v1/islands/items/usages`)에 아이템별 모델 URI 리스트 추가
- 건물 관련 모든 API의 `BuildingInfoDto.model` 필드를 실제 파일명에서 전체 URI(modelUri)로 변경

### Feature

- `ItemModelUriResolver` 추가: ShopItem 코드로부터 glb 모델 URI 리스트 변환
- `BuildingModelUriResolver` 추가: `BuildingInfoDto.modelUri`에 들어갈 glb 전체 URI 생성
- `GET /v1/islands/items/usages` 응답에 `modelUri: List<String>` 필드 추가

### Refactor

- `building_metadata.sql` model 필드값을 실제 glb 파일명 형식으로 변경
   - e.g. `model_wind_01` → `production_wind_generator`
- `BuildingInfoDto.model` → `modelUri` 리네임 및 전체 URI 반환으로 변경
   - 적용 범위: `SlotQueryService`, `BuildingUpgradeService`, `BuildingOperateService`, `BuildingLayoutService`, `BuildingMoveService`, `BuildingHarvestService`
- `ItemCatalogDto`에서 `iconUri` 필드 제거 (레벨업 해금 아이템 목록에서 불필요하다고 판단)

## 상세 설명

### 나무, 쓰레기(소), 쓰레기(대) 모델 URI 
아이템 사용량을 조회하는`GET /v1/islands/items/usages` API에서 모델 URI 제공하도록 추가했습니다. (아이템 사용량에 따라 렌더링하는 걸로 이해해서 이렇게 하긴 했는데 혹시 다른 방법이 더 낫다하시면 말씀부탁드려요ㅠㅠ!)

| 아이템 코드 | 반환 모델 |
|---|---|
| `TREE_PLANTING` | `tree_1.glb`, `tree_2.glb` |
| `TRASH_REMOVAL_SMALL` | `trash_small_1.glb` ~ `trash_small_10.glb` |
| `TRASH_REMOVAL_LARGE` | `trash_large_1.glb` ~ `trash_large_3.glb` |
| 그 외 | `[]` |

```json
{
  "code": "COMMON_200",
  "message": "성공입니다.",
  "data": [
    {
      "currentCount": 0,
      "expReward": 50,
      "itemId": 1,
      "maxCount": 10,
      "modelUri": [
        "https://image.sonyk9919.store:20024/models/trash_small_1.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_2.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_3.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_4.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_5.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_6.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_7.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_8.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_9.glb",
        "https://image.sonyk9919.store:20024/models/trash_small_10.glb"
      ],
      "name": "쓰레기 제거 (소)",
      "price": 25,
      "purchasable": false,
      "unlockLevel": 2
    },
    {
      "currentCount": 0,
      "expReward": 70,
      "itemId": 2,
      "maxCount": 3,
      "modelUri": [
        "https://image.sonyk9919.store:20024/models/trash_large_1.glb",
        "https://image.sonyk9919.store:20024/models/trash_large_2.glb",
        "https://image.sonyk9919.store:20024/models/trash_large_3.glb"
      ],
      "name": "쓰레기 제거 (대)",
      "price": 40,
      "purchasable": false,
      "unlockLevel": 3
    },
    {
      "currentCount": 0,
      "expReward": 125,
      "itemId": 3,
      "maxCount": 4,
      "modelUri": [],
      "name": "토양 정화",
      "price": 50,
      "purchasable": false,
      "unlockLevel": 2
    },
    {
      "currentCount": 0,
      "expReward": 125,
      "itemId": 4,
      "maxCount": 10,
      "modelUri": [],
      "name": "수질 개선",
      "price": 50,
      "purchasable": false,
      "unlockLevel": 4
    },
    {
      "currentCount": 0,
      "expReward": 75,
      "itemId": 5,
      "maxCount": 10,
      "modelUri": [
        "https://image.sonyk9919.store:20024/models/tree_1.glb",
        "https://image.sonyk9919.store:20024/models/tree_2.glb"
      ],
      "name": "나무 심기",
      "price": 30,
      "purchasable": false,
      "unlockLevel": 5
    }
  ]
}
```
(수질 개선이나 토양정화 아이템에서는 빈 배열을 반환하는 게 좀 깔끔하지 않은 것도 같아서... 의견 주시면 감사하겠습니다 ㅠㅠ)

### 건물 모델 URI 
건물 관련 모든 API에서 `BuildingInfoDto`의 `model` 필드가 `modelUri`로 변경되며, 파일명 대신 전체 URI를 반환합니다.

```
// 변경 전
{ "model": "production_wind_generator" }

// 변경 후
{ "modelUri": "https://image.sonyk9919.store:20024/models/production_wind_generator.glb" }
```

영향받는 API:
```
GET /v1/slots
GET /v1/slots/{slotNumber}
POST /v1/slots/{slotNumber}/buildings
DELETE /v1/slots/{slotNumber}/buildings
PATCH /v1/slots/{slotNumber}/buildings/level
POST /v1/slots/{slotNumber}/buildings/operate
POST /v1/slots/{slotNumber}/buildings/harvest
POST /v1/islands/buildings/harvest
POST /v1/slots/move
```

## Jira 링크

- https://untitled.atlassian.net/browse/KAN-520

## 참고사항
- 모든 glb 파일은 `https://image.sonyk9919.store:20024/models/` 경로에서 서빙됩니다.
- 나무, 쓰레기 소&대  오브젝트 URI를 섬 단위로 한번에 내려주는 구조가 필요하다면 `GET /v1/islands` 응답에 `sceneModels` 필드를 추가하는 방안도 고려 가능