### PR TITLE
chore: 데모를 위한 최대 레벨 및 재화 추가 API

### DIFF
--- a/src/main/java/store/sonyk9919/api/domain/island/controller/CheatController.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/controller/CheatController.java
@@ -1,0 +1,38 @@
+package store.sonyk9919.api.domain.island.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import store.sonyk9919.api.domain.auth.dto.AuthMemberDto;
+import store.sonyk9919.api.domain.auth.entity.AuthMember;
+import store.sonyk9919.api.domain.island.dto.ResourceBalanceResponse;
+import store.sonyk9919.api.domain.island.service.CheatService;
+
+@RestController
+@RequestMapping("/v1/cheat")
+@RequiredArgsConstructor
+public class CheatController {
+
+    private final CheatService cheatService;
+
+    @Operation(summary = "치트 적용", description = "섬을 최종 레벨로 설정하고 모든 재화를 10,000,000으로 설정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "치트 적용 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "섬을 찾을 수 없음")
+    })
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ResourceBalanceResponse apply(
+            @Parameter(hidden = true) @AuthMember AuthMemberDto authMember
+    ) {
+        return cheatService.apply(authMember.getId());
+    }
+}

--- a/src/main/java/store/sonyk9919/api/domain/island/entity/MemberIsland.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/MemberIsland.java
@@ -96,6 +96,10 @@ public class MemberIsland {
         itemContributionExp = 0;
     }
 
+    public void forceMaxLevel() {
+        this.level = MAX_LEVEL;
+    }
+
     public boolean isSameRegion(Region other) {
         return this.region == other;
     }

--- a/src/main/java/store/sonyk9919/api/domain/island/entity/MemberResource.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/entity/MemberResource.java
@@ -57,4 +57,8 @@ public class MemberResource {
         if (this.amount - amount < 0) throw new CustomException(IslandStatus.INSUFFICIENT_AMOUNT);
         this.amount -= amount;
     }
+
+    public void overrideAmount(long amount) {
+        this.amount = amount;
+    }
 }

--- a/src/main/java/store/sonyk9919/api/domain/island/service/CheatService.java
+++ b/src/main/java/store/sonyk9919/api/domain/island/service/CheatService.java
@@ -1,0 +1,35 @@
+package store.sonyk9919.api.domain.island.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import store.sonyk9919.api.domain.island.dto.ResourceBalanceResponse;
+import store.sonyk9919.api.domain.island.entity.MemberIsland;
+import store.sonyk9919.api.domain.island.entity.MemberResource;
+import store.sonyk9919.api.domain.island.exception.IslandStatus;
+import store.sonyk9919.api.domain.island.repository.MemberIslandRepository;
+import store.sonyk9919.api.domain.island.repository.MemberResourceRepository;
+import store.sonyk9919.api.global.common.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CheatService {
+
+    private static final long CHEAT_RESOURCE_AMOUNT = 10_000_000L;
+
+    private final MemberIslandRepository memberIslandRepository;
+    private final MemberResourceRepository memberResourceRepository;
+
+    public ResourceBalanceResponse apply(Long memberAccountId) {
+        MemberIsland island = memberIslandRepository.findByMemberAccountId(memberAccountId)
+                .orElseThrow(() -> new CustomException(IslandStatus.NOT_FOUND_ISLAND));
+        island.forceMaxLevel();
+
+        List<MemberResource> resources = memberResourceRepository.findAllByIslandMemberAccountId(memberAccountId);
+        resources.forEach(r -> r.overrideAmount(CHEAT_RESOURCE_AMOUNT));
+
+        return ResourceBalanceResponse.from(resources);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

### Feature

- 데모를 위해 로그인 계정의 최대 레벨 및 재화를 추가하는 API를 추가하였습니다.

## 참고사항

- 리뷰 없이 병합하겠습니다.
