### PR TITLE
fix: application 설정 파일에 gem_item.sql 데이터 초기화 누락 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,6 +25,7 @@ spring:
         - classpath:/db/analysis-example.sql
         - classpath:/db/trash-example.sql
         - classpath:/db/shop_item.sql
+        - classpath:/db/gem_item.sql
         - classpath:/db/level_spec.sql
         - classpath:/db/building_metadata.sql
         - classpath:/db/building_yield.sql

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,7 @@ spring:
         - classpath:/db/analysis-example.sql
         - classpath:/db/trash-example.sql
         - classpath:/db/shop_item.sql
+        - classpath:/db/gem_item.sql
         - classpath:/db/level_spec.sql
         - classpath:/db/building_metadata.sql
         - classpath:/db/building_yield.sql


### PR DESCRIPTION
## 주요 변경사항

`application-dev.yml`, `application-prod.yml`의 SQL 초기화 목록에 누락돼있던 `gem_item.sql`을 추가했습니다.

### Fix
- `application-dev.yml` data-locations에 `classpath:/db/gem_item.sql` 추가
- `application-prod.yml` data-locations에 `classpath:/db/gem_item.sql` 추가

## 상세 설명

`GET /v1/shops/gem-items` 호출 시 빈 배열이 반환되는 문제가 있었습니다.

### 원인
`gem_item.sql` 파일은 존재했지만 `application-dev.yml`과 `application-prod.yml` 양쪽 모두 `sql.init.data-locations`에 등록되지 않았습니다. 
두 환경 모두 `ddl-auto: create`로 설정되어 있어 서버 기동 시마다 `GEM_ITEM` 테이블이 새로 생성되지만 데이터는 INSERT되지 않은 상태로 유지됐습니다. 
이 상태에서 첫 번째 요청이 들어오면 `GemItemCache`가 빈 배열을 Redis에 캐싱하고, 이후 서버를 재시작해도 Redis 캐시가 유지되기 때문에 계속 빈 배열이 반환됐습니다.

### 해결
두 환경의 `data-locations`에 `gem_item.sql`을 추가하여 서버 기동 시 `GEM_ITEM` 테이블에 데이터가 정상 초기화되도록 수정했고,
그리고 Redis 캐시를 초기화했습니다.

## 체크리스트
- [x] `GEM_ITEM` 테이블에 데이터 정상 INSERT 확인 (dev)
- [x] `GET /v1/shops/gem-items` 응답에 아이템 목록 정상 반환 확인 (dev)
- [x] 배포 후 redis-cli 명령어로 Redis 캐시 초기화 후, 정상 반환 확인

## 참고사항
- 데모 준비를 위해 리뷰 없이 우선 병합하겠습니다!